### PR TITLE
syncing up main and develop

### DIFF
--- a/app/src/main/java/com/example/jetpacktest/ApiHandler.kt
+++ b/app/src/main/java/com/example/jetpacktest/ApiHandler.kt
@@ -1,6 +1,31 @@
 package com.example.jetpacktest
 
-//Used in ProfileScreen.kt when user selects 2024 as chosenYear, in order to get current API stats
+import android.util.Log
+import com.example.jetpacktest.models.PlayerPersonalInfo
+import retrofit2.HttpException
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
 class ApiHandler {
-    fun fetchPlayerData() {}
+    private val basePlayerUrl = Keys.BDL_BASE_URL
+
+    suspend fun fetchPlayerInfo(playerName: String): PlayerPersonalInfo {
+        val noAccentPlayerName = removeAccents(playerName) // Remove accent for API
+        val retrofitBuilder = Retrofit.Builder()
+            .addConverterFactory(GsonConverterFactory.create())
+            .baseUrl(basePlayerUrl)
+            .build()
+            .create(ApiInterface::class.java)
+        val nameParts = noAccentPlayerName.split(" ".toRegex(), limit = 2)
+        return try {
+            retrofitBuilder.getPersonalInfo(
+                firstName = nameParts[0],
+                lastName = nameParts[1]
+            )
+        } catch (e: HttpException) {
+            Log.d("ApiHandler", "HTTP Exception during API call: ${e.message}")
+            PlayerPersonalInfo(emptyList())
+        }
+
+    }
 }

--- a/app/src/main/java/com/example/jetpacktest/ApiInterface.kt
+++ b/app/src/main/java/com/example/jetpacktest/ApiInterface.kt
@@ -1,6 +1,8 @@
 package com.example.jetpacktest
 
 import com.example.jetpacktest.models.GameResponse
+import com.example.jetpacktest.models.InjuredPlayer
+import com.example.jetpacktest.models.PlayerPersonalInfo
 import com.example.jetpacktest.models.RestPlayer
 import retrofit2.Call
 import retrofit2.http.GET
@@ -9,9 +11,16 @@ import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface ApiInterface {
-    @Headers("Authorization: ${Keys.BDLAPIKey}")
+    @Headers("Authorization: ${Keys.BDL_API_KEY}")
     @GET("games")
     fun getGames(@Query("dates[]") date: String): Call<GameResponse>
+
+    @Headers("Authorization: ${Keys.BDL_API_KEY}")
+    @GET("players")
+    suspend fun getPersonalInfo(
+        @Query("first_name") firstName: String,
+        @Query("last_name") lastName: String
+    ): PlayerPersonalInfo
 
     @GET("PlayersActiveBasic")
     fun getActivePlayers(@Query("key") apiKey: String): Call<List<ActivePlayer>>
@@ -23,6 +32,9 @@ interface ApiInterface {
     @GET("PlayersBasic/{team}")
     fun getPlayersByTeam(@Path("team") team: String, @Query("key") apiKey: String) :
             Call<List<TeamPlayer>>
+
+    @GET("InjuredPlayers")
+    suspend fun getInjuredPlayers(@Query("key") apiKey: String) : List<InjuredPlayer>
 
     //Endpoints to fetch DB data from REST API
     @GET("player")

--- a/app/src/main/java/com/example/jetpacktest/DatabaseHandler.kt
+++ b/app/src/main/java/com/example/jetpacktest/DatabaseHandler.kt
@@ -1,8 +1,12 @@
 package com.example.jetpacktest
 
 import android.util.Log
+import com.example.jetpacktest.models.InjuredPlayer
 import com.example.jetpacktest.models.Player
 import com.example.jetpacktest.models.StatLeader
+import com.example.jetpacktest.models.TeamMaps
+import com.example.jetpacktest.models.TeamStanding
+import com.example.jetpacktest.models.TeamStanding.Conference
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -13,33 +17,19 @@ import java.sql.ResultSet
 import java.sql.SQLException
 import java.sql.Statement
 import java.text.Normalizer
-import java.util.concurrent.Executor
-import java.util.concurrent.Executors
 
 class DatabaseHandler {
-    object Const { // We use object since only way to make them constant
-        //Tag for logging
+    object Const {
         const val TAG = "DatabaseHandler"
-        //Constant to hold how many players to grab (top 10, top 20, etc.)
-        const val MAX_PLAYERS = 10
+        const val NUM_PLAYERS_TO_GRAB = 10
     }
-    //Executor for the database requesting (used to run in background as its own thread)
-    private val executor: Executor = Executors.newSingleThreadExecutor()
-    //Alternative to Executor
     private val scope = CoroutineScope(Dispatchers.IO)
-    //Variables and info to connect to DB
     private val url = "jdbc:mysql://nikoarak.cikeys.com:3306/nikoarak_SESports"
-    private val user = Keys.DBUser
-    private val password = Keys.DBPass
+    private val user = Keys.DB_USER
+    private val password = Keys.DB_PASS
 
     fun executeStatLeaders(chosenStat: String, year: String,
                            onDataReceived: (MutableList<StatLeader>) -> Unit) {
-        /*
-        executor.execute {
-            val statLeadersList = getStatLeaders(chosenStat, year)
-            onDataReceived(statLeadersList)
-        }
-         */
         scope.launch {
             val statLeadersList = getStatLeaders(chosenStat, year)
             withContext(Dispatchers.IO) {
@@ -48,12 +38,6 @@ class DatabaseHandler {
         }
     }
     fun executeYears(playerName: String, onDataReceived: (MutableList<String>) -> Unit) {
-        /*
-        executor.execute {
-            val yearsList = getPlayerYears(playerName)
-            onDataReceived(yearsList)
-        }
-         */
         scope.launch {
             val yearsList = getPlayerYears(playerName)
             withContext(Dispatchers.IO) {
@@ -64,12 +48,6 @@ class DatabaseHandler {
     }
     fun executePlayerData(playerName: String, year: String,
                           onDataReceived: (Player) -> Unit) {
-        /*
-        executor.execute {
-            val player = getPlayerData(playerName, year)
-            onDataReceived(player)
-        }
-         */
         scope.launch {
             val player = getPlayerData(playerName, year)
             withContext(Dispatchers.IO) {
@@ -80,13 +58,6 @@ class DatabaseHandler {
 
     fun executePlayerSearchResults(searchResultName: String,
                                    onDataReceived: (MutableList<String>) -> Unit) {
-        /*
-        executor.execute {
-            val playerResultsList = getPlayerSearchResults(searchResultName)
-            // After getting list of results, callback to calling function to send back the data
-            onDataReceived(playerResultsList)
-        }
-         */
         scope.launch {
             val playerResultsList = getPlayerSearchResults(searchResultName)
             withContext(Dispatchers.IO) {
@@ -97,12 +68,6 @@ class DatabaseHandler {
 
     fun executeRandomStat(randIndex: Int,
                           onDataReceived: (String) -> Unit) {
-        /*
-        executor.execute {
-            val randomStat = getRandomStat(randIndex)
-            onDataReceived(randomStat)
-        }
-         */
         scope.launch {
             val randomStat = getRandomStat(randIndex)
             withContext(Dispatchers.IO) {
@@ -121,6 +86,130 @@ class DatabaseHandler {
         }
     }
 
+    fun executeStoreInjured(injuredPlayers: List<InjuredPlayer>) {
+        scope.launch {
+            storeInjuredPlayers(injuredPlayers)
+        }
+    }
+
+    fun executeCheckInjuredStartDate(playerName: String, onDataReceived: (String) -> Unit) {
+        scope.launch {
+            val injuryStartDate: String = checkInjuredStartDate(playerName = playerName)
+            withContext(Dispatchers.IO) {
+                onDataReceived(injuryStartDate)
+            }
+        }
+    }
+
+    private fun checkInjuredStartDate(playerName: String): String {
+        var injuredStartDate = ""
+        var myConn: Connection? = null
+        var statement: Statement? = null
+        var resultSet: ResultSet? = null
+        try {
+            Class.forName("com.mysql.jdbc.Driver")
+            myConn = DriverManager.getConnection(url, user, password)
+            statement = myConn.createStatement()
+            val sql = "SELECT `InjuryStartDate` FROM INJURED_PLAYER WHERE `Name` = \"$playerName\""
+            resultSet = statement.executeQuery(sql)
+            while (resultSet.next()) {
+                injuredStartDate = resultSet.getString("InjuryStartDate")
+                Log.d("DatabaseHandler", "Player was injured on $injuredStartDate")
+            }
+        } catch (e: SQLException) {
+            Log.d(Const.TAG, e.message!!)
+            e.printStackTrace()
+        } catch (e: ClassNotFoundException) {
+            e.printStackTrace()
+        } finally {
+            closeResources(myConn, resultSet, statement)
+        }
+        return if (injuredStartDate == "") "N/A"
+        else injuredStartDate
+    }
+
+    private fun storeInjuredPlayers(injuredPlayers: List<InjuredPlayer>) {
+        var myConn: Connection? = null
+        var statement: Statement? = null
+        try {
+            Log.d("DatabaseHandler", "Storing new list of injured players...")
+            Class.forName("com.mysql.jdbc.Driver")
+            myConn = DriverManager.getConnection(url, user, password)
+            statement = myConn.createStatement()
+            //Prevents previous injuries from displaying
+            statement.executeUpdate("DELETE FROM INJURED_PLAYER")
+            //PreparedStatement for re-usability
+            val preparedStatement = myConn.prepareStatement(
+                "INSERT INTO INJURED_PLAYER (`Name`, `InjuryStartDate`) VALUES (?, ?)"
+            )
+            injuredPlayers.forEach {injuredPlayer ->
+                val fullName = "${injuredPlayer.firstName} ${injuredPlayer.lastName}"
+                val injuryStartDate = injuredPlayer.injuryStartDate
+                preparedStatement.setString(1, fullName)
+                preparedStatement.setString(2, injuryStartDate)
+                preparedStatement.executeUpdate()
+            }
+            Log.d("DatabaseHandler", "Finished storing list...")
+        } catch (e: SQLException) {
+            Log.d(Const.TAG, e.message!!)
+            e.printStackTrace()
+        } catch (e: ClassNotFoundException) {
+            e.printStackTrace()
+        } finally {
+            closeResources(myConn, null, statement)
+        }
+    }
+
+    fun executeStandings(conference: Conference, onDataReceived: (MutableList<TeamStanding>) -> Unit) {
+        scope.launch {
+            val standingsList = getStandings(conference)
+            onDataReceived(standingsList)
+        }
+    }
+
+    private fun getStandings(conference: Conference): MutableList<TeamStanding> {
+        var myConn: Connection? = null
+        var statement: Statement? = null
+        var resultSet: ResultSet? = null
+        val teamPlayers = mutableListOf<TeamStanding>()
+        try {
+            Class.forName("com.mysql.jdbc.Driver")
+            myConn = DriverManager.getConnection(url, user, password)
+            statement = myConn.createStatement()
+            val sql = "SELECT* FROM ${conference.name}_STANDING"
+            resultSet = statement.executeQuery(sql)
+            while (resultSet.next()) {
+                val teamName = resultSet.getString("Team_Name")
+                val abbrev = when (teamName) {
+                    "New York Knicks" -> "NYK" // These 4 have their third letter cut off
+                    "New Orleans Pelicans" -> "NOP"
+                    "San Antonio Spurs" -> "SAS"
+                    "Golden State Warriors" -> "GSW"
+                    else -> TeamMaps.namesToAbbreviations[teamName] ?: "N/A"
+                }
+                val teamStanding = TeamStanding(
+                    rank = resultSet.getInt("rank"),
+                    name = teamName,
+                    wins = resultSet.getInt("Wins"),
+                    losses = resultSet.getInt("Losses"),
+                    winLossPercentage = resultSet.getFloat("Win_Loss_Percentage"),
+                    conference = conference,
+                    logo = TeamMaps.xmlLogos[teamName] ?: R.drawable.baseline_arrow_back_ios_new_24,
+                    abbrev = abbrev
+                )
+                teamPlayers.add(teamStanding)
+            }
+        } catch (e: SQLException) {
+            Log.d(Const.TAG, e.message!!)
+            e.printStackTrace()
+        } catch (e: ClassNotFoundException) {
+            e.printStackTrace()
+        } finally {
+            closeResources(myConn, resultSet, statement)
+        }
+        return teamPlayers
+    }
+
     private fun getNbaDotComId(playerName: String): Int {
         var id: Int = -1
         var myConn: Connection? = null
@@ -130,7 +219,7 @@ class DatabaseHandler {
             Class.forName("com.mysql.jdbc.Driver")
             myConn = DriverManager.getConnection(url, user, password)
             statement = myConn.createStatement()
-            val sql = "SELECT `NbaId` FROM NBA_PLAYER_ID WHERE `Name` = '$playerName'"
+            val sql = "SELECT `NbaId` FROM NBA_PLAYER_ID WHERE `Name` = \"$playerName\""
             resultSet = statement.executeQuery(sql)
             while (resultSet.next()) {
                 id = resultSet.getInt("NbaId")
@@ -141,14 +230,12 @@ class DatabaseHandler {
         } catch (e: ClassNotFoundException) {
             e.printStackTrace()
         } finally {
-            //Close resources
             closeResources(myConn, resultSet, statement)
         }
         return id
     }
 
     private fun getRandomStat(randIndex: Int): String {
-        Log.d("DatabaseHandler", "Fetching new random stat")
         var randomStat = ""
         var myConn: Connection? = null
         var statement: Statement? = null
@@ -168,46 +255,16 @@ class DatabaseHandler {
         } catch (e: ClassNotFoundException) {
             e.printStackTrace()
         } finally {
-            //Close resources
             closeResources(myConn, resultSet, statement)
         }
         return randomStat
     }
-
-    private fun oldGetRandomStat(): String {
-        var randomStat = ""
-        var myConn: Connection? = null
-        var statement: Statement? = null
-        var resultSet: ResultSet? = null
-        try {
-            Class.forName("com.mysql.jdbc.Driver")
-            myConn = DriverManager.getConnection(url, user, password)
-            statement = myConn.createStatement()
-            val sql = "SELECT statString FROM RANDOM_STAT ORDER BY RAND() LIMIT 1"
-            resultSet = statement.executeQuery(sql)
-            while (resultSet.next()) {
-                randomStat = resultSet.getString("statString")
-            }
-        } catch (e: SQLException) {
-            Log.d(Const.TAG, e.message!!)
-            e.printStackTrace()
-        } catch (e: ClassNotFoundException) {
-            e.printStackTrace()
-        } finally {
-            //Close resources
-            closeResources(myConn, resultSet, statement)
-        }
-        return randomStat
-    }
-
-
 
     private fun getPlayerSearchResults(searchResultName: String): MutableList<String> {
         val playerResultsList = mutableListOf<String>()
         var myConn: Connection? = null
         var statement: Statement? = null
         var resultSet: ResultSet? = null
-        //We remove accents since searching DB requires none
         val searchResultsNameNoAccents = removeAccents(searchResultName)
         try {
             Log.d("DatabaseHandler", "Fetching new search results")
@@ -229,18 +286,16 @@ class DatabaseHandler {
         } catch (e: ClassNotFoundException) {
             e.printStackTrace()
         } finally {
-            //Close resources
             closeResources(myConn, resultSet, statement)
         }
         return playerResultsList
     }
 
-    //This function uses DB to store all data in a player object and returns
     private fun getPlayerData(playerName: String, year: String): Player {
         var myConn: Connection? = null
         var statement: Statement? = null
         var resultSet: ResultSet? = null
-        var player = Player() //Instantiate with secondary constructor
+        var player = Player()
         //Remove accents since can't have any when searching DB
         val playerNameNoAccents = removeAccents(playerName)
         try {
@@ -298,14 +353,12 @@ class DatabaseHandler {
                     }
                 }
                 //Now, we've set all fields except team name, so do that now
-                //We needed to change team to var for this
                 player.team = appendedTeam.dropLast(1) // Drop trailing slash
             }
             //Otherwise, we only have one record and can just grab all our data
             else {
-                //First, need to point resultSet one ahead so it actually points at first row (not b4)
+                //Point resultSet one ahead to point at actual data
                 resultSet.next()
-                //Give player instance all the fitting params in constructor
                 player = Player(
                     name = resultSet.getString("Player"),
                     year = resultSet.getInt("Year"),
@@ -339,7 +392,6 @@ class DatabaseHandler {
         } catch (e: ClassNotFoundException) {
             e.printStackTrace()
         } finally {
-            //Close resources
             closeResources(myConn, resultSet, statement)
         }
         return player
@@ -376,7 +428,7 @@ class DatabaseHandler {
                     statData.append("Player Name: ").append(playerName).append(", ")
                         .append(chosenStat).append(": ").append(chosenStatValue).append("\n")
                     counter++
-                    if (counter >= Const.MAX_PLAYERS) break // break out after grabbing top x players
+                    if (counter >= Const.NUM_PLAYERS_TO_GRAB) break // break out after grabbing top x players
                 }
             }
         } catch (e: SQLException) {
@@ -385,7 +437,6 @@ class DatabaseHandler {
         } catch (e: ClassNotFoundException) {
             e.printStackTrace()
         } finally {
-            //Close resources
             closeResources(myConn, resultSet, statement)
         }
         return statLeadersList
@@ -418,7 +469,6 @@ class DatabaseHandler {
         } catch (e: ClassNotFoundException) {
             e.printStackTrace()
         } finally {
-            //Close resources
             closeResources(myConn, resultSet, statement)
         }
         return yearsList

--- a/app/src/main/java/com/example/jetpacktest/FavoritesHandler.kt
+++ b/app/src/main/java/com/example/jetpacktest/FavoritesHandler.kt
@@ -1,0 +1,38 @@
+package com.example.jetpacktest
+
+import android.content.Context
+import android.content.SharedPreferences
+
+class FavoritesHandler(context: Context) {
+    companion object {
+        const val FAVORITE_LIMIT = 5
+    }
+    private val sharedPreferences: SharedPreferences =
+        context.getSharedPreferences("favorites_prefs", Context.MODE_PRIVATE)
+
+    fun getFavoritePlayers(): Set<String> {
+        return sharedPreferences.getStringSet("favorite_players", emptySet()) ?: emptySet()
+    }
+
+    fun addFavoritePlayer(playerName: String): Boolean {
+        val favoritePlayers = getFavoritePlayers().toMutableSet()
+        return if (favoritePlayers.size < FAVORITE_LIMIT) {
+            favoritePlayers.add(playerName)
+            saveFavoritePlayers(favoritePlayers)
+            true
+        } else false // Return false on error
+    }
+
+    fun removeFavoritePlayer(playerName: String) {
+        val favoritePlayers = getFavoritePlayers().toMutableSet()
+        favoritePlayers.remove(playerName)
+        saveFavoritePlayers(favoritePlayers)
+    }
+
+    private fun saveFavoritePlayers(favoritePlayers: Set<String>) {
+        with(sharedPreferences.edit()) {
+            putStringSet("favorite_players", favoritePlayers)
+            apply()
+        }
+    }
+}

--- a/app/src/main/java/com/example/jetpacktest/GamesHandler.kt
+++ b/app/src/main/java/com/example/jetpacktest/GamesHandler.kt
@@ -10,7 +10,7 @@ import android.util.Log
 //Custom models/object
 import com.example.jetpacktest.models.Game
 import com.example.jetpacktest.models.GameResponse
-import com.example.jetpacktest.models.NbaTeam
+import com.example.jetpacktest.models.TeamMaps
 //For date operations
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -22,9 +22,9 @@ import org.threeten.bp.format.DateTimeFormatter
 
 class GamesHandler {
     //ApiInterface adds the 'games' endpoint, as well as the date query for us
-    private val baseGameUrl = "https://api.balldontlie.io/v1/"
+    private val baseGameUrl = Keys.BDL_BASE_URL
 
-    fun fetchGames(date: Date, onResult: (MutableList<Game>) -> Unit) {
+    fun fetchGames(date: Date, onResult: (MutableList<Game>?) -> Unit) {
         //We first must convert our date into a usable format
         val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
         val formattedDate = dateFormat.format(date)
@@ -42,9 +42,9 @@ class GamesHandler {
                     val responseBody = response.body()!!
                     for (game in responseBody.data) {
                         //Set the logos that weren't in JSON.
-                        game.home_team.logo = NbaTeam.xmlLogos[game.home_team.name] ?:
+                        game.homeTeam.logo = TeamMaps.xmlLogos[game.homeTeam.name] ?:
                                 R.drawable.baseline_arrow_back_ios_new_24
-                        game.visitor_team.logo = NbaTeam.xmlLogos[game.visitor_team.name] ?:
+                        game.visitorTeam.logo = TeamMaps.xmlLogos[game.visitorTeam.name] ?:
                                 R.drawable.baseline_arrow_back_ios_new_24
                         //gameTime set to Final means game ended, null means hasn't started
                         if (game.time.isNullOrEmpty() || game.time == "Final") game.time = ""
@@ -54,7 +54,8 @@ class GamesHandler {
                         }
                         gamesList.add(game)
                     }
-                    onResult(gamesList)
+                    if (gamesList.isNotEmpty()) onResult(gamesList)
+                    else onResult(null)
                 }
                 else { Log.d("GamesHandler", "Retrofit: Unsuccessful Response") }
             }

--- a/app/src/main/java/com/example/jetpacktest/InjuryWorker.kt
+++ b/app/src/main/java/com/example/jetpacktest/InjuryWorker.kt
@@ -1,0 +1,30 @@
+package com.example.jetpacktest
+
+import android.content.Context
+import android.util.Log
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+class InjuryWorker(appContext: Context, workerParams: WorkerParameters):
+    CoroutineWorker(appContext, workerParams) {
+    private val databaseHandler = DatabaseHandler()
+    private val injuryApiBaseUrl = "https://api.sportsdata.io/v3/nba/projections/json/"
+    override suspend fun doWork(): Result {
+        val retrofitBuilder = Retrofit.Builder()
+            .addConverterFactory(GsonConverterFactory.create())
+            .baseUrl(injuryApiBaseUrl)
+            .build()
+            .create(ApiInterface::class.java)
+        //Fetch list of injuredPlayers
+        Log.d("InjuryWorker", "InjuryWorker is active, calling API")
+        val injuredPlayers = retrofitBuilder.getInjuredPlayers(Keys.SPORTS_DATA_IO_KEY)
+        //Store in database if found
+        injuredPlayers.let {
+            databaseHandler.executeStoreInjured(injuredPlayers = injuredPlayers)
+        }
+        // Indicate whether the work finished successfully with the Result
+        return Result.success()
+    }
+}

--- a/app/src/main/java/com/example/jetpacktest/Keys.kt
+++ b/app/src/main/java/com/example/jetpacktest/Keys.kt
@@ -2,11 +2,13 @@ package com.example.jetpacktest
 
 object Keys { // Change BuildConfig values in local.properties
     //Get Key from https://sportsdata.io/nba-api
-    const val SportsDataAPIKey = BuildConfig.SPORTS_DATA_IO_KEY
+    const val SPORTS_DATA_IO_KEY = BuildConfig.SPORTS_DATA_IO_KEY
     //Get Key from https://www.balldontlie.io/#introduction
-    const val BDLAPIKey = BuildConfig.BDL_KEY
+    const val BDL_API_KEY = BuildConfig.BDL_KEY
     //DB login for connecting
-    const val DBUser = BuildConfig.DB_USER
-    const val DBPass = BuildConfig.DB_PASS
+    const val DB_USER = BuildConfig.DB_USER
+    const val DB_PASS = BuildConfig.DB_PASS
+
+    const val BDL_BASE_URL = "https://api.balldontlie.io/v1/"
 
 }

--- a/app/src/main/java/com/example/jetpacktest/MainActivity.kt
+++ b/app/src/main/java/com/example/jetpacktest/MainActivity.kt
@@ -13,19 +13,18 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.PeriodicWorkRequest
 import androidx.work.PeriodicWorkRequestBuilder
-import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import com.example.jetpacktest.navigation.AppNavigation
 import com.example.jetpacktest.ui.theme.JetpackTestTheme
 import com.jakewharton.threetenabp.AndroidThreeTen
-import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
 
 
 class MainActivity : ComponentActivity() {
     private lateinit var sharedPreferences: SharedPreferences
     companion object {
-        private const val TAG = "RandomStatWork"
+        private const val RANDOM_STAT_TAG = "RandomStatWork"
+        private const val INJURY_TAG = "InjuryWork"
     }
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -38,15 +37,12 @@ class MainActivity : ComponentActivity() {
                 .build()
         )
          */
-        //Updates new randomStat value if new day has passed and fetches
-        //TODO: Might not need this helper, will test tomorrow, also need to make index async
-        if(!isWorkScheduled()) {
-            //scheduleWork()
-        }
-        scheduleWork()
+        //For obtaining random stat (if new day has passed)
+        scheduleRandomStatWork()
         sharedPreferences = applicationContext.getSharedPreferences("prefs", MODE_PRIVATE)
         val randomStat = sharedPreferences.getString(RandomStatWorker.KEY_RANDOM_STAT, "test") ?: ""
-
+        //For storing new injury data (if week has passed)
+        scheduleInjuredWork()
         //Initializes timezone used in GamesScreen.kt
         AndroidThreeTen.init(this)
         setContent {
@@ -63,38 +59,30 @@ class MainActivity : ComponentActivity() {
         }
     }
 
-    private fun scheduleWork() {
+    private fun scheduleRandomStatWork() {
         //Sets up and submits work request, only runs every 24 hours
         val randomStatRequest: PeriodicWorkRequest =
             PeriodicWorkRequestBuilder<RandomStatWorker>(24, TimeUnit.HOURS)
                 .build()
         val workManager = WorkManager.getInstance(applicationContext)
         workManager.enqueueUniquePeriodicWork(
-            TAG,
+            RANDOM_STAT_TAG,
             ExistingPeriodicWorkPolicy.KEEP,
             randomStatRequest
         )
     }
 
-    private fun isWorkScheduled(): Boolean {
-        //Checks if there's not already an instance scheduled
-        val instance = WorkManager.getInstance(applicationContext)
-        val statuses = instance.getWorkInfosByTag(TAG)
-        return try {
-            var running = false
-            val workInfoList = statuses.get()
-            for (workInfo in workInfoList) {
-                val state = workInfo.state
-                running = (state == WorkInfo.State.RUNNING) or (state == WorkInfo.State.ENQUEUED)
-            }
-            running
-        } catch (e: ExecutionException) {
-            e.printStackTrace()
-            false
-        } catch (e: InterruptedException) {
-            e.printStackTrace()
-            false
-        }
+    private fun scheduleInjuredWork() {
+        //Sets up and submits work request, only runs every week
+        val injuredPlayerRequest: PeriodicWorkRequest =
+            PeriodicWorkRequestBuilder<InjuryWorker>(7, TimeUnit.DAYS)
+                .build()
+        val workManager = WorkManager.getInstance(applicationContext)
+        workManager.enqueueUniquePeriodicWork(
+            INJURY_TAG,
+            ExistingPeriodicWorkPolicy.KEEP,
+            injuredPlayerRequest
+        )
     }
 }
 

--- a/app/src/main/java/com/example/jetpacktest/TeamHandler.kt
+++ b/app/src/main/java/com/example/jetpacktest/TeamHandler.kt
@@ -1,12 +1,7 @@
 package com.example.jetpacktest
 
-import android.content.Context
 import android.util.Log
-import com.android.volley.Request
-import com.android.volley.toolbox.JsonArrayRequest
-import com.android.volley.toolbox.Volley
-import org.json.JSONArray
-import org.json.JSONException
+import com.google.gson.annotations.SerializedName
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
@@ -14,31 +9,43 @@ import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
 data class TeamPlayer (
-    val BirthCity: String,
-    val BirthCountry: String,
-    val BirthDate: String,
-    val BirthState: String,
-    val FirstName: String,
-    val GlobalTeamID: Int,
-    val Height: Int,
-    val Jersey: Int,
-    val LastName: String,
-    val PlayerID: Int,
-    val Position: String,
-    val PositionCategory: String,
-    val SportsDataID: String,
-    val Status: String,
-    val Team: String,
-    val TeamID: Int,
-    val Weight: Int
+    @SerializedName("BirthCity")
+    val birthCity: String,
+    @SerializedName("BirthCountry")
+    val birthCountry: String,
+    @SerializedName("BirthDate")
+    val birthDate: String,
+    @SerializedName("BirthState")
+    val birthState: String,
+    @SerializedName("FirstName")
+    val firstName: String,
+    @SerializedName("GlobalTeamID")
+    val globalTeamId: Int,
+    @SerializedName("Height")
+    val height: Int,
+    @SerializedName("Jersey")
+    val jersey: Int,
+    @SerializedName("LastName")
+    val lastName: String,
+    @SerializedName("PlayerID")
+    val playerId: Int,
+    @SerializedName("Position")
+    val position: String,
+    @SerializedName("PositionCategory")
+    val positionCategory: String,
+    @SerializedName("SportsDataID")
+    val sportsDataId: String,
+    @SerializedName("Status")
+    val status: String,
+    @SerializedName("Team")
+    val team: String,
+    @SerializedName("TeamID")
+    val teamId: Int,
+    @SerializedName("Weight")
+    val weight: Int
 )
 
 class TeamHandler {
-    //API Key and prefix of URL (we will append the team abbreviation, and key in fetchTeamPlayers)
-    private val apiKey = Keys.SportsDataAPIKey
-    private val teamPlayersUrlPrefix = "https://api.sportsdata.io/v3/nba/scores/json/PlayersBasic/"
-    private var playerRows = mutableListOf<String>()
-
     fun fetchCurrentRoster(teamAbbrev: String, onResult: (MutableList<TeamPlayer>) -> Unit) {
         val basePlayersByTeamUrl = "https://api.sportsdata.io/v3/nba/scores/json/"
         val teamPlayersList = mutableListOf<TeamPlayer>()
@@ -49,7 +56,7 @@ class TeamHandler {
             .create(ApiInterface::class.java)
         val retrofitPlayers = retrofitBuilder.getPlayersByTeam(
             team = teamAbbrev,
-            apiKey = Keys.SportsDataAPIKey
+            apiKey = Keys.SPORTS_DATA_IO_KEY
         )
         retrofitPlayers.enqueue(object : Callback<List<TeamPlayer>?> {
             override fun onResponse(call: Call<List<TeamPlayer>?>, response: Response<List<TeamPlayer>?>) {
@@ -66,40 +73,5 @@ class TeamHandler {
             override fun onFailure(call: Call<List<TeamPlayer>?>, t: Throwable) {
                 Log.d("TeamHandler", "Retrofit failure: $t")            }
         })
-    }
-
-    fun fetchTeamPlayers(teamAbbrev: String, context: Context, onResult: (MutableList<String>) -> Unit) {
-        val teamPlayersUrl = "$teamPlayersUrlPrefix$teamAbbrev?key=$apiKey"
-        val request = JsonArrayRequest(
-            Request.Method.GET, teamPlayersUrl, null,
-            { response ->
-                try {
-                    //Parse through list of playerNames via function below
-                    playerRows = parsePlayersJsonResponse(response)
-                    //Return back these names using our callback function (needed b/c async)
-                    onResult(playerRows)
-                } catch (e: JSONException) {
-                    e.printStackTrace() // Prints error in logcat
-                }
-            }) { error -> error.printStackTrace() } // Prints error in logcat
-        //Use context we passed in
-        Volley.newRequestQueue(context.applicationContext).add(request)
-    }
-
-    private fun parsePlayersJsonResponse(jsonArray: JSONArray): MutableList<String> {
-        for (i in 0 until jsonArray.length()) {
-            //Loop through array and get the ith JSON object
-            val player = jsonArray.getJSONObject(i)
-            //Then, retrieve the firstName/lastName fields and append for full name
-            val firstName = player.getString("FirstName")
-            val lastName = player.getString("LastName")
-            val jerseyNum = player.optInt("Jersey", -1)
-            val position = player.getString("Position")
-            // Check if jerseyNum was -1 aka null, if so, replace it with "N/A"
-            val jerseyText = if (jerseyNum == -1) "N/A" else "#$jerseyNum"
-            val playerRow = "$firstName $lastName - $jerseyText - $position"
-            playerRows.add(playerRow)
-        }
-        return playerRows
     }
 }

--- a/app/src/main/java/com/example/jetpacktest/Utilities.kt
+++ b/app/src/main/java/com/example/jetpacktest/Utilities.kt
@@ -1,0 +1,19 @@
+package com.example.jetpacktest
+
+import java.text.Normalizer
+
+//Niko: Helper function to remove accents from playerName, since API we use needs raw
+//Got it from https://stackoverflow.com/a/3322174
+fun removeAccents(input: String): String {
+    return Normalizer.normalize(input, Normalizer.Form.NFD)
+        .replace("\\p{InCombiningDiacriticalMarks}+".toRegex(), "")
+}
+
+fun dropZeroBeforeDecimal(input: Float): String {
+    val inputStr = input.toString()
+    return if (inputStr.startsWith("0.")) {
+        inputStr.drop(1)
+    } else {
+        inputStr
+    }
+}

--- a/app/src/main/java/com/example/jetpacktest/models/Game.kt
+++ b/app/src/main/java/com/example/jetpacktest/models/Game.kt
@@ -1,6 +1,6 @@
 package com.example.jetpacktest.models
 
-import com.example.jetpacktest.R
+import com.google.gson.annotations.SerializedName
 
 data class GameResponse(
     val data: List<Game>
@@ -10,10 +10,14 @@ data class Game(
     var status: String, //TODO fix var
     val period: Int,
     var time: String?, //TODO fix var
-    val home_team_score: Int,
-    val visitor_team_score: Int,
-    val home_team: Team,
-    val visitor_team: Team
+    @SerializedName("home_team_score")
+    val homeTeamScore: Int,
+    @SerializedName("visitor_team_score")
+    val visitorTeamScore: Int,
+    @SerializedName("home_team")
+    val homeTeam: Team,
+    @SerializedName("visitor_team")
+    val visitorTeam: Team
 )
 
 data class Team(
@@ -22,20 +26,8 @@ data class Team(
     val division: String,
     val city: String,
     val name: String,
-    val full_name: String,
+    @SerializedName("full_name")
+    val fullName: String,
     val abbreviation: String,
-    var logo: Int
-    //val logo: Int = NbaTeam.xmlLogos[name] ?: R.drawable.fallback
-)
-
-//Was using in volley
-data class GameOld(
-    val homeName: String,
-    val awayName: String,
-    val homeScore: String,
-    val awayScore: String,
-    val gameStatus: String,
-    val gameTime: String,
-    val homeLogo: Int,
-    val awayLogo: Int
+    var logo: Int //TODO fix var
 )

--- a/app/src/main/java/com/example/jetpacktest/models/InjuredPlayer.kt
+++ b/app/src/main/java/com/example/jetpacktest/models/InjuredPlayer.kt
@@ -1,0 +1,13 @@
+package com.example.jetpacktest.models
+
+
+import com.google.gson.annotations.SerializedName
+
+data class InjuredPlayer(
+    @SerializedName("FirstName")
+    val firstName: String,
+    @SerializedName("LastName")
+    val lastName: String,
+    @SerializedName("InjuryStartDate")
+    val injuryStartDate: String,
+)

--- a/app/src/main/java/com/example/jetpacktest/models/PlayerPersonalInfo.kt
+++ b/app/src/main/java/com/example/jetpacktest/models/PlayerPersonalInfo.kt
@@ -1,0 +1,32 @@
+package com.example.jetpacktest.models
+
+
+import android.os.Parcelable
+import com.google.gson.annotations.SerializedName
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class PlayerPersonalInfo(
+    val `data`: List<Data>,
+) : Parcelable
+
+@Parcelize
+data class Data(
+    @SerializedName("first_name")
+    val firstName: String,
+    @SerializedName("last_name")
+    val lastName: String,
+    val position: String,
+    val height: String,
+    val weight: String,
+    @SerializedName("jersey_number")
+    val jerseyNumber: String,
+    val college: String,
+    val country: String,
+    @SerializedName("draft_year")
+    val draftYear: Int,
+    @SerializedName("draft_round")
+    val draftRound: Int,
+    @SerializedName("draft_number")
+    val draftNumber: Int,
+) : Parcelable

--- a/app/src/main/java/com/example/jetpacktest/models/TeamMaps.kt
+++ b/app/src/main/java/com/example/jetpacktest/models/TeamMaps.kt
@@ -2,21 +2,7 @@ package com.example.jetpacktest.models
 
 import com.example.jetpacktest.R
 
-//Used in TeamProfile and Standings
-//For fetching standings, fetching player names of team we wont use an object since its only name field)
-data class TeamStanding(
-    val city: String,
-    val name: String,
-    val conference: Conference,
-    val wins: Int,
-    val losses: Int,
-    val percentage: Double
-)
-enum class Conference {
-    WESTERN,
-    EASTERN
-}
-object NbaTeam { // We use object so it's a singleton that we don't have to instantiate like a class
+object TeamMaps {
     //Team Names, used in SearchScreen.kt when searching for teams
     val names = listOf(
         "Atlanta Hawks",
@@ -75,6 +61,7 @@ object NbaTeam { // We use object so it's a singleton that we don't have to inst
         "Oklahoma City Thunder" to "OKC",
         "Orlando Magic" to "ORL",
         "Philadelphia Sixers" to "PHI",
+        "Philadelphia 76ers" to "PHI",
         "Phoenix Suns" to "PHO",
         "Portland Trail Blazers" to "POR",
         "Sacramento Kings" to "SAC",
@@ -118,38 +105,68 @@ object NbaTeam { // We use object so it's a singleton that we don't have to inst
         "Washington Wizards" to R.drawable.wizards
     )
 
-    //Map names to xml drawables, used in GamesScreen
+    //Map names to xml drawables,
     val xmlLogos: Map<String, Int> = mapOf(
         "Hawks" to R.drawable.xml_hawks,
+        "Atlanta Hawks" to R.drawable.xml_hawks,
         "Celtics" to R.drawable.xml_celtics,
+        "Boston Celtics" to R.drawable.xml_celtics,
         "Nets" to R.drawable.xml_nets,
+        "Brooklyn Nets" to R.drawable.xml_nets,
         "Hornets" to R.drawable.xml_hornets,
+        "Charlotte Hornets" to R.drawable.xml_hornets,
         "Bulls" to R.drawable.xml_bulls,
+        "Chicago Bulls" to R.drawable.xml_bulls,
         "Cavaliers" to R.drawable.xml_cavaliers,
+        "Cleveland Cavaliers" to R.drawable.xml_cavaliers,
         "Mavericks" to R.drawable.xml_mavericks,
+        "Dallas Mavericks" to R.drawable.xml_mavericks,
         "Nuggets" to R.drawable.xml_nuggets,
+        "Denver Nuggets" to R.drawable.xml_nuggets,
         "Pistons" to R.drawable.xml_pistons,
+        "Detroit Pistons" to R.drawable.xml_pistons,
         "Warriors" to R.drawable.xml_warriors,
+        "Golden State Warriors" to R.drawable.xml_warriors,
         "Rockets" to R.drawable.xml_rockets,
+        "Houston Rockets" to R.drawable.xml_rockets,
         "Pacers" to R.drawable.xml_pacers,
+        "Indiana Pacers" to R.drawable.xml_pacers,
         "Clippers" to R.drawable.xml_clippers,
+        "Los Angeles Clippers" to R.drawable.xml_clippers,
         "Lakers" to R.drawable.xml_lakers,
+        "Los Angeles Lakers" to R.drawable.xml_lakers,
         "Grizzlies" to R.drawable.xml_grizzlies,
+        "Memphis Grizzlies" to R.drawable.xml_grizzlies,
         "Heat" to R.drawable.xml_heat,
+        "Miami Heat" to R.drawable.xml_heat,
         "Bucks" to R.drawable.xml_bucks,
+        "Milwaukee Bucks" to R.drawable.xml_bucks,
         "Timberwolves" to R.drawable.xml_timberwolves,
+        "Minnesota Timberwolves" to R.drawable.xml_timberwolves,
         "Pelicans" to R.drawable.xml_pelicans,
+        "New Orleans Pelicans" to R.drawable.xml_pelicans,
         "Knicks" to R.drawable.xml_knicks,
+        "New York Knicks" to R.drawable.xml_knicks,
         "Thunder" to R.drawable.xml_thunder,
+        "Oklahoma City Thunder" to R.drawable.xml_thunder,
         "Magic" to R.drawable.xml_magic,
+        "Orlando Magic" to R.drawable.xml_magic,
         "76ers" to R.drawable.xml_sixers,
+        "Philadelphia 76ers" to R.drawable.xml_sixers,
         "Suns" to R.drawable.xml_suns,
+        "Phoenix Suns" to R.drawable.xml_suns,
         "Trail Blazers" to R.drawable.xml_trailblazers,
+        "Portland Trail Blazers" to R.drawable.xml_trailblazers,
         "Kings" to R.drawable.xml_kings,
+        "Sacramento Kings" to R.drawable.xml_kings,
         "Spurs" to R.drawable.xml_spurs,
+        "San Antonio Spurs" to R.drawable.xml_spurs,
         "Raptors" to R.drawable.xml_raptors,
+        "Toronto Raptors" to R.drawable.xml_raptors,
         "Jazz" to R.drawable.xml_jazz,
-        "Wizards" to R.drawable.xml_wizards
+        "Utah Jazz" to R.drawable.xml_jazz,
+        "Wizards" to R.drawable.xml_wizards,
+        "Washington Wizards" to R.drawable.xml_wizards
     )
 
     val shortenedNamesToFullNames: Map<String, String> = mapOf(

--- a/app/src/main/java/com/example/jetpacktest/models/TeamStanding.kt
+++ b/app/src/main/java/com/example/jetpacktest/models/TeamStanding.kt
@@ -1,0 +1,17 @@
+package com.example.jetpacktest.models
+
+data class TeamStanding(
+    val rank: Int,
+    val name: String,
+    val wins: Int,
+    val losses: Int,
+    val winLossPercentage: Float,
+    val conference: Conference,
+    val logo: Int,
+    val abbrev: String
+) {
+    enum class Conference {
+        WESTERN,
+        EASTERN
+    }
+}

--- a/app/src/main/java/com/example/jetpacktest/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/jetpacktest/navigation/AppNavigation.kt
@@ -12,10 +12,14 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavDestination.Companion.hierarchy
@@ -24,6 +28,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.example.jetpacktest.screens.BracketsScreen
 import com.example.jetpacktest.screens.CompareResultsScreen
 import com.example.jetpacktest.screens.CompareScreen
 import com.example.jetpacktest.screens.HomeScreen
@@ -32,13 +37,22 @@ import com.example.jetpacktest.screens.SearchScreen
 import com.example.jetpacktest.screens.GamesScreen
 import com.example.jetpacktest.screens.StandingsScreen
 import com.example.jetpacktest.screens.TeamProfileScreen
+import com.example.jetpacktest.viewmodels.StandingsViewModel
+import kotlinx.coroutines.launch
 
 @Composable
 fun AppNavigation(randomStat: String) {
     val navController = rememberNavController()
     val searchViewModel = viewModel<SearchViewModel>()
     val homeViewModel = viewModel<HomeViewModel>()
+    val standingsViewModel = viewModel<StandingsViewModel>()
+    val getPreviousScreenName: () -> (String?) = {
+        navController.previousBackStackEntry?.destination?.route
+    }
+    val snackbarHostState = remember { SnackbarHostState() }
+    val coroutineScope = rememberCoroutineScope() // Required for snackbar
     Scaffold(
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState)},
         bottomBar = {
             NavigationBar {
                 val navBackStackEntry by navController.currentBackStackEntryAsState()
@@ -71,7 +85,7 @@ fun AppNavigation(randomStat: String) {
                 }
             }
         }
-    ) {paddingValues ->
+    ) { paddingValues ->
         NavHost(navController = navController,
             startDestination = Screens.HomeScreen.name,
             modifier = Modifier
@@ -85,7 +99,9 @@ fun AppNavigation(randomStat: String) {
                     homeViewModel = homeViewModel,
                     //Pass in a lambda that'll let us go to a stat leader's profile on click
                     navigateToPlayerProfile = { playerName ->
-                        navController.navigate("${Screens.ProfileScreen.route}/$playerName")
+                        navController.navigate("${Screens.ProfileScreen.route}/$playerName") {
+                            launchSingleTop = true //Prevents double click navigation
+                        }
                     }
                 )
             }
@@ -106,35 +122,76 @@ fun AppNavigation(randomStat: String) {
                     clearResults = { searchViewModel.clearResults() },
                     //Two more lambdas that will let us access team/player profiles on click
                     navigateToPlayerProfile = { playerName ->
-                        navController.navigate("${Screens.ProfileScreen.route}/$playerName")
+                        navController.navigate("${Screens.ProfileScreen.route}/$playerName") {
+                            launchSingleTop = true
+                        }
                     },
                     navigateToTeamProfile = { teamName ->
-                        navController.navigate("${Screens.TeamProfileScreen.route}/$teamName")
+                        navController.navigate("${Screens.TeamProfileScreen.route}/$teamName") {
+                            launchSingleTop = true
+                        }
                     }
                 )
             }
             composable(route = Screens.CompareScreen.name) {
                 CompareScreen(
                     navigateToCompareResults = { playerName1, playerName2 ->
-                        navController.navigate("${Screens.CompareResultsScreen.route}/$playerName1/$playerName2")
+                        navController.navigate("${Screens.CompareResultsScreen.route}/$playerName1/$playerName2") {
+                            launchSingleTop = true
+                        }
                     }
                 )
             }
+            val navigateToTeamProfile: (String) -> Unit = { teamName ->
+                navController.navigate("${Screens.TeamProfileScreen.route}/$teamName") {
+                    launchSingleTop = true
+                }
+            }
+            val navigateToBrackets: () -> Unit = {
+                navController.navigate(Screens.BracketsScreen.name)
+            }
             composable(route = Screens.StandingsScreen.name) {
-                    StandingsScreen()
+                StandingsScreen(
+                    westernFlow = standingsViewModel.westernFlow,
+                    easternFlow = standingsViewModel.easternFlow,
+                    navigateToTeamProfile = navigateToTeamProfile,
+                    navigateToBrackets = navigateToBrackets
+                )
+            }
+            composable(
+                route = Screens.BracketsScreen.name,
+                enterTransition = {
+                    slideInHorizontally(
+                        initialOffsetX = { it },
+                        animationSpec = tween(
+                            300,
+                            easing = FastOutLinearInEasing
+                        )
+                    )
+                },
+                exitTransition = {
+                    slideOutHorizontally(
+                        targetOffsetX = { -it },
+                        animationSpec = tween(
+                            300,
+                            easing = FastOutLinearInEasing
+                        )
+                    )
+                }
+            ) {
+                BracketsScreen(
+                    navigateBack = { navController.navigateUp() },
+                )
             }
             composable(route=Screens.GamesScreen.name) {
                 GamesScreen(
-                    //Pass in lambda that lets us go to team profile from logo click
-                    navigateToTeamProfile = { teamName ->
-                        navController.navigate("${Screens.TeamProfileScreen.route}/$teamName")
-                    }
+                    navigateToTeamProfile = navigateToTeamProfile
                 )
             }
             composable(route = "${Screens.CompareResultsScreen.route}/{playerName1}/{playerName2}",
                 enterTransition = {
                     slideInHorizontally(
-                        initialOffsetX = {it },
+                        initialOffsetX = { it },
                         animationSpec = tween(
                             300,
                             easing = FastOutLinearInEasing
@@ -157,7 +214,7 @@ fun AppNavigation(randomStat: String) {
                     navController.popBackStack()
                 }
             }
-            //Profile screens for player/team (we pass in player/team name as arg in route), not on nav bar
+            //Profile screens for player/team (we pass in player/team name as arg in route)
             composable(route = "${Screens.ProfileScreen.route}/{playerName}",
                 enterTransition = {
                     slideInHorizontally(
@@ -179,10 +236,18 @@ fun AppNavigation(randomStat: String) {
                 }
             ) { backStackEntry ->
                 val playerName = backStackEntry.arguments?.getString("playerName") ?: ""
-                ProfileScreen(playerName) {
-                    //Used for back button
-                    navController.navigateUp()
-                }
+                ProfileScreen(
+                    playerName = playerName,
+                    navigateBack = { navController.navigateUp() },
+                    getPreviousScreenName = getPreviousScreenName,
+                    showSnackBar = { message ->
+                        coroutineScope.launch {
+                            snackbarHostState.showSnackbar(
+                                message = message
+                            )
+                        }
+                    }
+                )
             }
             composable(route = "${Screens.TeamProfileScreen.route}/{teamName}",
                 enterTransition = {
@@ -210,10 +275,15 @@ fun AppNavigation(randomStat: String) {
                     navigateBack = { navController.popBackStack()},
                     //When user clicks on a current player of a team, we'll use this to switch over
                     navigateToPlayerProfile = { playerName ->
-                        navController.navigate("${Screens.ProfileScreen.route}/$playerName") }
+                        navController.navigate(
+                            "${Screens.ProfileScreen.route}/$playerName"
+                        ) {
+                            launchSingleTop = true
+                        }
+                    },
+                    getPreviousScreenName = getPreviousScreenName
                 )
             }
         }
-
     }
 }

--- a/app/src/main/java/com/example/jetpacktest/navigation/Screens.kt
+++ b/app/src/main/java/com/example/jetpacktest/navigation/Screens.kt
@@ -8,5 +8,6 @@ enum class Screens(val route: String) {
     ProfileScreen("profile"),
     TeamProfileScreen("teamprofile"),
     StandingsScreen("standings"),
+    BracketsScreen("brackets"),
     GamesScreen("games"),
 }

--- a/app/src/main/java/com/example/jetpacktest/screens/BracketsScreen.kt
+++ b/app/src/main/java/com/example/jetpacktest/screens/BracketsScreen.kt
@@ -1,0 +1,208 @@
+package com.example.jetpacktest.screens
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DataSaverOff
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.surfaceColorAtElevation
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.example.jetpacktest.R
+import com.example.jetpacktest.ui.components.ReturnToPreviousHeader
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun BracketsScreen(navigateBack: () -> Unit) {
+    LazyColumn(
+        modifier = Modifier
+            .padding(horizontal = 16.dp)
+  //          .fillMaxSize()
+  //          .background(Color.DarkGray)
+    ) {
+        stickyHeader {
+            ReturnToPreviousHeader(
+                navigateBack = navigateBack,
+                label = "Standings Screen"
+            )
+        }
+        item { Spacer(modifier = Modifier.height(16.dp)) }
+        item {
+            LazyRow {
+                //Column for each round
+                item { FirstRoundColumn() }
+                item { Spacer(modifier = Modifier.width(20.dp)) }
+                item { SecondRoundColumn() }
+                item { Spacer(modifier = Modifier.width(20.dp)) }
+                item { ThirdRoundColumn() }
+                item { Spacer(modifier = Modifier.width(20.dp)) }
+                item { FourthRoundColumn() }
+            }
+        }
+        item { Spacer(modifier = Modifier.height(16.dp)) }
+    }
+}
+@Composable
+private fun FirstRoundColumn() {
+    Column {
+        val firstRoundMatchups = listOf(
+            Pair("OKC   1", "NOLA  0") to Pair(R.drawable.xml_thunder, R.drawable.xml_pelicans),
+            Pair("LAL   0", "DEN   2") to Pair(R.drawable.xml_lakers, R.drawable.xml_nuggets),
+            Pair("MIN   2", "PHX   0") to Pair(R.drawable.xml_timberwolves, R.drawable.xml_suns),
+            Pair("LAC   1", "DAL   1") to Pair(R.drawable.xml_clippers, R.drawable.xml_mavericks),
+            Pair("BOS   1", "MIA   0") to Pair(R.drawable.xml_celtics, R.drawable.xml_heat),
+            Pair("NYK   2", "PHI   0") to Pair(R.drawable.xml_knicks, R.drawable.xml_sixers),
+            Pair("MIL   1", "IND   1") to Pair(R.drawable.xml_bucks, R.drawable.xml_pacers),
+            Pair("CLE   2", "ORL   0") to Pair(R.drawable.xml_cavaliers, R.drawable.xml_magic)
+        )
+
+        firstRoundMatchups.forEach { (teams, logos) ->
+            BracketMatchup(teams.first, teams.second, logos.first, logos.second, tbd = false)
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
+}
+
+@Composable
+private fun SecondRoundColumn() {
+    Column {
+        Spacer(modifier = Modifier.height(70.dp))
+
+        val secondRoundMatchups = listOf(
+            Pair("Winner   1", "Winner   2") to Pair(R.drawable.xml_thunder, R.drawable.xml_lakers),
+            Pair("Winner   3", "Winner   4") to Pair(R.drawable.xml_timberwolves, R.drawable.xml_mavericks),
+            Pair("Winner   5", "Winner   6") to Pair(R.drawable.xml_celtics, R.drawable.xml_knicks),
+            Pair("Winner   7", "Winner   8") to Pair(R.drawable.xml_cavaliers, R.drawable.xml_bucks)
+        )
+
+        secondRoundMatchups.forEachIndexed { index, (teams, logos) ->
+            if (index > 0 ) {
+                Spacer(modifier = Modifier.height(175.dp))
+            }
+            BracketMatchup(teams.first, teams.second, logos.first, logos.second, tbd = true)
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
+}
+
+@Composable
+private fun ThirdRoundColumn() {
+    Column {
+        Spacer(modifier = Modifier.height(215.dp))
+
+        val thirdRoundMatchups = listOf(
+            Pair("Winner   1", "Winner   3") to Pair(R.drawable.xml_thunder, R.drawable.xml_timberwolves),
+            Pair("Winner   5", "Winner   7") to Pair(R.drawable.xml_celtics, R.drawable.xml_cavaliers),
+        )
+
+        thirdRoundMatchups.forEachIndexed { index, (teams, logos) ->
+            if (index > 0) {
+                Spacer(modifier = Modifier.height(460.dp))
+            }
+            BracketMatchup(teams.first, teams.second, logos.first, logos.second, tbd = true)
+        }
+    }
+}
+
+@Composable
+private fun FourthRoundColumn() {
+    Column {
+        Spacer(modifier = Modifier.height(450.dp))
+
+        val fourthRoundMatchups = listOf(
+            Pair("Winner   1", "Winner   5") to Pair(R.drawable.xml_thunder, R.drawable.xml_celtics),
+        )
+
+        fourthRoundMatchups.forEach { (teams, logos) ->
+            BracketMatchup(teams.first, teams.second, logos.first, logos.second, tbd = true)
+        }
+    }
+}
+
+@Composable
+fun BracketMatchup(
+    teamAName: String, teamBName: String, teamALogo: Int, teamBLogo: Int, tbd: Boolean
+) {
+    Card(
+        modifier = Modifier.padding(16.dp),
+        elevation = CardDefaults.cardElevation(
+            defaultElevation = 10.dp
+        ),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(3.dp),
+            contentColor = Color.Black
+        )
+    ) {
+        Column {
+            BracketRow(teamName = teamAName, logoResId = teamALogo, tbd = tbd)
+            Spacer(modifier = Modifier.height(10.dp))
+            BracketRow(teamName = teamBName, logoResId = teamBLogo, tbd = tbd)
+        }
+    }
+}
+
+@Composable
+fun BracketRow(teamName: String, logoResId: Int, tbd: Boolean) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 8.dp)
+    ) {
+        if (tbd) {
+            Icon(
+                imageVector = Icons.Default.DataSaverOff,
+                contentDescription = null
+            )
+        }
+        else {
+            Image(
+                painter = painterResource(id = logoResId),
+                contentDescription = "Team Logo",
+                modifier = Modifier
+                    .size(40.dp)
+                    .clip(RoundedCornerShape(4.dp))
+            )
+        }
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(text = teamName)
+    }
+}
+
+
+/*
+@Composable
+fun BracketLine() {
+    Canvas(modifier = Modifier
+        .fillMaxWidth()
+        .height(16.dp)) {
+        drawLine(
+            color = Color.Black,
+            start = Offset(size.width / 2, 0f),
+            end = Offset(size.width / 2, size.height),
+            strokeWidth = 2.dp.toPx(),
+            cap = StrokeCap.Round
+        )
+    }
+}
+ */

--- a/app/src/main/java/com/example/jetpacktest/screens/CompareResultsScreen.kt
+++ b/app/src/main/java/com/example/jetpacktest/screens/CompareResultsScreen.kt
@@ -1,36 +1,36 @@
 package com.example.jetpacktest.screens
 
-import ReturnToPreviousHeader
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.jetpacktest.DatabaseHandler
 import com.example.jetpacktest.R
-import com.example.jetpacktest.models.NbaTeam
 import com.example.jetpacktest.models.Player
 import com.example.jetpacktest.ui.components.CircularLoadingIcon
 import com.example.jetpacktest.ui.components.LargeDropdownMenu
+import com.example.jetpacktest.ui.components.ReturnToPreviousHeader
 
 @Composable
-fun CompareResultsScreen(playerName1: String, playerName2: String,navigateBack: () -> Unit,
-                         ) {
+fun CompareResultsScreen(playerName1: String, playerName2: String,navigateBack: () -> Unit) {
     val databaseHandler = DatabaseHandler()
     var player1 by remember { mutableStateOf(Player()) }
     var player2 by remember { mutableStateOf(Player()) }
@@ -40,8 +40,6 @@ fun CompareResultsScreen(playerName1: String, playerName2: String,navigateBack: 
     var yearsList2 by remember { mutableStateOf<List<String>>(emptyList()) }
     var isFetching1 by remember { mutableStateOf(false)}
     var isFetching2 by remember { mutableStateOf(false)}
-
-
 
     LaunchedEffect(Unit) {
         isFetching1 = true
@@ -70,182 +68,226 @@ fun CompareResultsScreen(playerName1: String, playerName2: String,navigateBack: 
         }
     }
 
-    Surface(modifier = Modifier.fillMaxSize(), color = Color.White) {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(16.dp)
-                .verticalScroll(rememberScrollState())
-        ) {
-            ReturnToPreviousHeader(navigateBack = navigateBack)
-            Spacer(modifier = Modifier.height(15.dp))
-            if (isFetching1 || isFetching2) {
-                CircularLoadingIcon()
-            }
-            else {
-                Row(modifier = Modifier.fillMaxWidth()) {
-                    LargeDropdownMenu(
-                        label = "Select ${player1.name}'s Year:",
-                        items = yearsList1,
-                        selectedIndex = yearsList1.indexOf(chosenYear1),
-                        onItemSelected = { index, _ ->
-                            val year = yearsList1[index]
-                            //Check if newly selected stat is different from previous
-                            if (year != chosenYear1) {
-                                chosenYear1 = year
-                                databaseHandler.executePlayerData(playerName1, chosenYear1) { data ->
-                                    player1 = data
-                                }
-                            }
-                        },
-                        modifier = Modifier.weight(1f)
-                    )
-                    LargeDropdownMenu(
-                        label = "Select ${player2.name}'s Year:",
-                        items = yearsList2,
-                        selectedIndex = yearsList2.indexOf(chosenYear2),
-                        onItemSelected = { index, _ ->
-                            val year = yearsList2[index]
-                            //Check if newly selected stat is different from previous
-                            if (year != chosenYear2) {
-                                chosenYear2 = year
-                                databaseHandler.executePlayerData(playerName2, chosenYear2) { data ->
-                                    player2 = data
-                                }
-                            }
-                        },
-                        modifier = Modifier.weight(1f)
-                    )
-                }
-                PlayerProfile(players = listOf(player1, player2))
-            }
-        }
-    }
-}
-
-@Composable
-fun PlayerProfile(players: List<Player>) {
-    val player1 = players.getOrNull(0)
-    val player2 = players.getOrNull(1)
-
-    HorizontalDivider()
-    player1?.let { player ->
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp)
-        ) {
-            Row(
-                modifier = Modifier.horizontalScroll(rememberScrollState())
-            ) {
-                Box(modifier = Modifier.padding(end = 16.dp)) {
-                    PlayerCard(player, player2!!)
-                }
-                Box(modifier = Modifier.padding(end = 16.dp)) {
-                    PlayerCard(player2!!, player1)
-                }
-            }
-        }
-    }
-}
-
-
-
-
-
-@Composable
-fun PlayerStats(player1: Player, player2: Player) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(16.dp)
-    ) {
-        PlayerCard(player1, player2)
-        PlayerCard(player2, player1)
-    }
-}
-
-@Composable
-fun PlayerCard(player: Player, opponent: Player) {
-    val team = player.team
-    Box(
+Surface(modifier = Modifier.fillMaxSize(), color = Color.White) {
+    Column(
         modifier = Modifier
-            .width(200.dp)
-            .shadow(elevation = 4.dp)
-            .border(width = 2.dp, color = Color.Gray, shape = RoundedCornerShape(8.dp)) // Border with rounded corners
+            .fillMaxSize()
+            .padding(8.dp)
     ) {
-        Box(
-            modifier = Modifier
-                .background(Color(0xFFF5F5DC)) // Beige background color
-                .padding(16.dp)
-        ) {
-            Column {
-                Text(
-                    text = player.name,
-                    fontSize = 20.sp,
-                    fontWeight = FontWeight.Bold,
-                    color = Color.Black
+        ReturnToPreviousHeader(navigateBack = navigateBack, label = "Compare")
+        Spacer(modifier = Modifier.height(15.dp))
+        if (isFetching1 || isFetching2) {
+            CircularLoadingIcon()
+        }
+        else {
+            Row(modifier = Modifier.fillMaxWidth()) {
+                LargeDropdownMenu(
+                    label = "Select ${player1.name}'s Year:",
+                    items = yearsList1,
+                    selectedIndex = yearsList1.indexOf(chosenYear1),
+                    onItemSelected = { index, _ ->
+                        val year = yearsList1[index]
+                        //Check if newly selected stat is different from previous
+                        if (year != chosenYear1) {
+                            chosenYear1 = year
+                            databaseHandler.executePlayerData(playerName1, chosenYear1) { data ->
+                                player1 = data
+                            }
+                        }
+                    },
+                    modifier = Modifier.weight(1f)
                 )
-                Spacer(modifier = Modifier.height(8.dp))
-                StatRow("Year", player.year.toString(), false)
-                StatRow("Position", player.position, false)
-                StatRow("Team", player.team, false)
-                StatRow("Points", player.points.toString(), player.points > opponent.points)
-                StatRow("Assists", player.assists.toString(), player.assists > opponent.assists)
-                StatRow("Steals", player.steals.toString(), player.steals > opponent.steals)
-                StatRow("Blocks", player.blocks.toString(), player.blocks > opponent.blocks)
-                StatRow("Total Rebounds", player.totalRebounds.toString(), player.totalRebounds > opponent.totalRebounds)
-                StatRow("Turnovers", player.turnovers.toString(), player.turnovers < opponent.turnovers)
-                StatRow("Personal Fouls", player.personalFouls.toString(), player.personalFouls < opponent.personalFouls)
-                StatRow("Minutes Played", player.minutesPlayed.toString(), player.minutesPlayed > opponent.minutesPlayed)
-                StatRow("FG", player.fieldGoals.toString(), player.fieldGoals > opponent.fieldGoals)
-                StatRow("FGA", player.fieldGoalAttempts.toString(), player.fieldGoalAttempts > opponent.fieldGoalAttempts)
-                StatRow("FG%", player.fieldGoalPercent.toString(), player.fieldGoalPercent > opponent.fieldGoalPercent)
-                StatRow("3P ", player.threePointers.toString(), player.threePointers > opponent.threePointers)
-                StatRow("3PA", player.threePointerAttempts.toString(), player.threePointerAttempts > opponent.threePointerAttempts)
-                StatRow("3P%", player.threePointPercent.toString(), player.threePointPercent > opponent.threePointPercent)
-                StatRow("2P", player.twoPointers.toString(), player.twoPointers > opponent.twoPointers)
-                StatRow("2PA", player.twoPointerAttempts.toString(), player.twoPointerAttempts > opponent.twoPointerAttempts)
-                StatRow("2P%", player.twoPointPercent.toString(), player.twoPointPercent > opponent.twoPointPercent)
-                StatRow("EFG%", player.effectiveFieldGoalPercent.toString(), player.effectiveFieldGoalPercent > opponent.effectiveFieldGoalPercent)
-                StatRow("ORB", player.offensiveRebounds.toString(), player.offensiveRebounds > opponent.offensiveRebounds)
-                StatRow("DRB", player.defensiveRebounds.toString(), player.defensiveRebounds > opponent.defensiveRebounds)
+                LargeDropdownMenu(
+                    label = "Select ${player2.name}'s Year:",
+                    items = yearsList2,
+                    selectedIndex = yearsList2.indexOf(chosenYear2),
+                    onItemSelected = { index, _ ->
+                        val year = yearsList2[index]
+                        //Check if newly selected stat is different from previous
+                        if (year != chosenYear2) {
+                            chosenYear2 = year
+                            databaseHandler.executePlayerData(playerName2, chosenYear2) { data ->
+                                player2 = data
+                            }
+                        }
+                    },
+                    modifier = Modifier.weight(1f)
+                )
             }
+            Spacer(modifier = Modifier.height(5.dp))
+            NameHeader(player1Name = player1.name, player2Name = player2.name)
+            Spacer(modifier = Modifier.height(5.dp))
+            DisplayComparison(player1, player2)
+        }
+    }
+}
+}
+
+@Composable
+fun DisplayComparison(player1: Player, player2: Player) {
+    Card(
+        modifier = Modifier.padding(8.dp),
+        elevation = CardDefaults.cardElevation(
+            defaultElevation = 10.dp
+        ),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(3.dp),
+            contentColor = Color.Black
+        ),
+        shape = RoundedCornerShape(8.dp)
+    ) {
+        PlayerCard(player1 = player1, player2 = player2)
+    }
+}
+
+@Composable
+fun PlayerCard(player1: Player, player2: Player) {
+    LazyColumn(
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        items(getPlayerStats(player1 = player1, player2 = player2)) { (statName, statValues) ->
+            val (player1Value, player2Value) = statValues // Unpack pair of stats
+            if (statName != "Team") {
+                StatRow(
+                    label = statName,
+                    player1Value = player1Value.toString(),
+                    player2Value = player2Value.toString(),
+                )
+            } else {
+                StatRow(
+                    label = statName,
+                    player1Value = player1.team,
+                    player2Value = player2.team,
+                )
+            }
+            HorizontalDivider(color = Color.Black)
         }
     }
 }
 
-
 @Composable
-fun StatRow(label: String, value: String, playerHasHigherStat: Boolean) {
-
-    val statColor = if (playerHasHigherStat) Color(0xFF46923c) else Color(0xFFF5F5DC)
-    val borderColor = Color(0xFFF5F5DC)
+fun NameHeader(player1Name: String, player2Name: String) {
     Row(
-        modifier = Modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(Color.White)
+            .padding(8.dp),
     ) {
         Text(
-            text = label,
-            fontSize = 16.sp,
+            text = player1Name,
+            fontSize = 20.sp,
             fontWeight = FontWeight.Bold,
+            color = Color.Black,
+            fontFamily = FontFamily.Serif,
             modifier = Modifier.weight(1f)
         )
-        Spacer(modifier = Modifier.width(8.dp))
-        Box(
-            modifier = Modifier
-                .background(statColor, RoundedCornerShape(4.dp))
-                .padding(horizontal = 4.dp, vertical = 2.dp)
-        ) {
-            Text(
-                text = value,
-                fontSize = 16.sp,
-                textAlign = TextAlign.End,
-                color = Color.Black,
-                modifier = Modifier.padding(horizontal = 4.dp)
-            )
-        }
+        Text(
+            text = player2Name,
+            fontSize = 20.sp,
+            fontWeight = FontWeight.Bold,
+            color = Color.Black,
+            fontFamily = FontFamily.Serif,
+            modifier = Modifier.weight(1f),
+            textAlign = TextAlign.End
+        )
     }
+}
+
+@Composable
+fun StatRow(label: String, player1Value: String, player2Value: String) {
+    val player1HasHigherStat = checkIfPlayer1HasHigherStat(
+        statName = label,
+        player1Value = player1Value,
+        player2Value = player2Value
+    )
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = player1Value,
+            fontSize = 20.sp,
+            fontFamily = FontFamily.Serif,
+            textAlign = TextAlign.Start,
+            modifier = Modifier
+                .wrapContentSize()
+                .background(
+                    if (player1HasHigherStat == true) colorResource(R.color.higherStat)
+                    else MaterialTheme.colorScheme.surfaceColorAtElevation(3.dp)
+                )
+                .weight(1.5f)
+                .padding(horizontal = 5.dp)
+        )
+        Text(
+            text = label,
+            fontSize = 20.sp,
+            fontFamily = FontFamily.Serif,
+            textAlign = TextAlign.Center,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier
+                .weight(2f)
+                .padding(horizontal = 5.dp)
+        )
+        Text(
+            text = player2Value,
+            fontSize = 20.sp,
+            fontFamily = FontFamily.Serif,
+            textAlign = TextAlign.End,
+            modifier = Modifier
+                .wrapContentSize()
+                .background(
+                    if (player1HasHigherStat == false) colorResource(R.color.higherStat)
+                    else MaterialTheme.colorScheme.surfaceColorAtElevation(3.dp)
+                )
+                .weight(1.5f)
+                .padding(horizontal = 5.dp)
+        )
+    }
+}
+
+private fun getPlayerStats(
+    player1: Player,
+    player2: Player
+): List<Pair<String, Pair<Float, Float>>> {
+    return listOf(
+        "Team" to Pair(player1.team.toFloatOrNull() ?: 0f, player2.team.toFloatOrNull() ?: 0f),
+        "Points" to Pair(player1.points, player2.points),
+        "Assists" to Pair(player1.assists, player2.assists),
+        "Steals" to Pair(player1.steals, player2.steals),
+        "Blocks" to Pair(player1.blocks, player2.blocks),
+        "Total Rebounds" to Pair(player1.totalRebounds, player2.totalRebounds),
+        "Turnovers" to Pair(player1.turnovers, player2.turnovers),
+        "Personal Fouls" to Pair(player1.personalFouls, player2.personalFouls),
+        "Minutes Played" to Pair(player1.minutesPlayed, player2.minutesPlayed),
+        "Field Goals" to Pair(player1.fieldGoals, player2.fieldGoals),
+        "Field Goal Attempts" to Pair(player1.fieldGoalAttempts, player2.fieldGoalAttempts),
+        "Field Goal %" to Pair(player1.fieldGoalPercent, player2.fieldGoalPercent),
+        "3 Pointers" to Pair(player1.threePointers, player2.threePointers),
+        "3 Point Attempts" to Pair(player1.threePointerAttempts, player2.threePointerAttempts),
+        "3 Point %" to Pair(player1.threePointPercent, player2.threePointPercent),
+        "2 Pointers" to Pair(player1.twoPointers, player2.twoPointers),
+        "2 Point Attempts" to Pair(player1.twoPointerAttempts, player2.twoPointerAttempts),
+        "2 Point %" to Pair(player1.twoPointPercent, player2.twoPointPercent),
+        "Effective Field Goal %" to Pair(player1.effectiveFieldGoalPercent,
+            player2.effectiveFieldGoalPercent),
+        "Offensive Rebounds" to Pair(player1.offensiveRebounds, player2.offensiveRebounds),
+        "Defensive Rebounds" to Pair(player1.defensiveRebounds, player2.defensiveRebounds)
+    )
+}
+
+private fun checkIfPlayer1HasHigherStat(
+    statName: String,
+    player1Value: String,
+    player2Value: String
+): Boolean? {
+    val player1Val = player1Value.toFloatOrNull()
+    val player2Val = player2Value.toFloatOrNull()
+
+    if (player1Val == null|| player2Val == null || player1Val == player2Val) return null
+    return if (statName == "Turnovers" || statName == "Personal Fouls") player1Val < player2Val
+    else player1Val > player2Val
 }
 
 

--- a/app/src/main/java/com/example/jetpacktest/screens/GamesScreen.kt
+++ b/app/src/main/java/com/example/jetpacktest/screens/GamesScreen.kt
@@ -19,11 +19,12 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -43,7 +44,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.jetpacktest.GamesHandler
 import com.example.jetpacktest.models.Game
-import com.example.jetpacktest.models.NbaTeam
+import com.example.jetpacktest.models.TeamMaps
 import com.example.jetpacktest.ui.components.CircularLoadingIcon
 import com.foreverrafs.datepicker.DatePickerTimeline
 import java.time.ZoneId
@@ -53,14 +54,13 @@ import java.util.Date
 @Composable
 fun GamesScreen(navigateToTeamProfile: (String) -> Unit) {
     val gamesHandler = GamesHandler()
-    //TODO: Make gamesList and list in TeamProfileScreen parcelable to work w/ savable
     var selectedDate by rememberSaveable { mutableStateOf(Date()) }
-    var gamesList by rememberSaveable { mutableStateOf<List<Game>>(emptyList()) }
-    var isFetching by remember { mutableStateOf(false)}
+    var gamesList by rememberSaveable { mutableStateOf<List<Game>?>(emptyList()) }
+    var isFetching by rememberSaveable { mutableStateOf(false)}
     var lastFetchedDate by remember { mutableStateOf(selectedDate) }
 
     LaunchedEffect(selectedDate) {
-        if (gamesList.isEmpty() || selectedDate != lastFetchedDate) {
+        if ( (gamesList != null && gamesList?.isEmpty()!!) || selectedDate != lastFetchedDate) {
             Log.d("GamesHandler", "Fetching new games...")
             isFetching = true
             gamesList = emptyList()
@@ -76,7 +76,7 @@ fun GamesScreen(navigateToTeamProfile: (String) -> Unit) {
         modifier = Modifier.fillMaxSize()
     ) {
         DatePickerTimeline(
-            backgroundColor = Color.LightGray,
+            backgroundColor = MaterialTheme.colorScheme.surfaceColorAtElevation(3.dp),
             onDateSelected = { selectedLocalDate ->
                 val newSelectedDate = Date.from(
                     selectedLocalDate.atStartOfDay(ZoneId.systemDefault()).toInstant()
@@ -95,9 +95,21 @@ fun GamesScreen(navigateToTeamProfile: (String) -> Unit) {
             }
         )
         if (!isFetching) {
-            LazyColumn(modifier = Modifier.weight(1f)) {
-                items(gamesList) { game ->
-                    GameCard(game = game, navigateToTeamProfile)
+            if (gamesList != null) {
+                LazyColumn(modifier = Modifier.weight(1f)) {
+                    items(gamesList!!) { game ->
+                        GameCard(game = game, navigateToTeamProfile)
+                    }
+                }
+            }
+            else {
+                Box(modifier = Modifier.fillMaxSize()) {
+                    Text(
+                        text = "Sorry! No games today",
+                        textAlign = TextAlign.Center,
+                        fontFamily = FontFamily.Serif,
+                        modifier = Modifier.align(Alignment.Center)
+                    )
                 }
             }
         }
@@ -128,30 +140,30 @@ fun GameCard(game: Game, navigateToTeamProfile: (String) -> Unit) {
                 horizontalArrangement = Arrangement.SpaceBetween
             ) {
                 Image(
-                    painter = painterResource(id = game.home_team.logo),
+                    painter = painterResource(id = game.homeTeam.logo),
                     contentDescription = "Home Team Logo",
                     modifier = Modifier
                         .size(50.dp)
                         //On click, nav to team profile, substituting e.g. Hawks with Atlanta Hawks
                         .clickable {
                             navigateToTeamProfile(
-                                NbaTeam.shortenedNamesToFullNames[game.home_team.name]
-                                    ?: game.home_team.name
+                                TeamMaps.shortenedNamesToFullNames[game.homeTeam.name]
+                                    ?: game.homeTeam.name
                             )
                         }
                 )
                 if (isGameUpcoming(game)) DisplayUpcomingInfo(game)
                 else DisplayOngoingOrPreviousInfo(game)
                 Image(
-                    painter = painterResource(id = game.visitor_team.logo),
+                    painter = painterResource(id = game.visitorTeam.logo),
                     contentDescription = "Away Team Logo",
                     modifier = Modifier
                         .size(50.dp)
                         //On click, nav to team profile, substituting e.g. Hawks with Atlanta Hawks
                         .clickable {
                             navigateToTeamProfile(
-                                NbaTeam.shortenedNamesToFullNames[game.visitor_team.name]
-                                    ?: game.visitor_team.name
+                                TeamMaps.shortenedNamesToFullNames[game.visitorTeam.name]
+                                    ?: game.visitorTeam.name
                             )
                         }
                 )
@@ -165,7 +177,7 @@ fun GameCard(game: Game, navigateToTeamProfile: (String) -> Unit) {
                 horizontalArrangement = Arrangement.SpaceBetween
             ) {
                 Text(
-                    text = game.home_team.name,
+                    text = game.homeTeam.name,
                     fontFamily = FontFamily.Serif,
                     fontWeight = FontWeight.Bold,
                     fontSize = 16.sp
@@ -173,7 +185,7 @@ fun GameCard(game: Game, navigateToTeamProfile: (String) -> Unit) {
                 // Spacer to create gap between home and away team names
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(
-                    text = game.visitor_team.name,
+                    text = game.visitorTeam.name,
                     fontFamily = FontFamily.Serif,
                     fontWeight = FontWeight.Bold,
                     fontSize = 16.sp
@@ -198,7 +210,7 @@ fun DisplayUpcomingInfo(game: Game) {
 @Composable
 fun DisplayOngoingOrPreviousInfo(game: Game) {
     Text(
-        text = game.home_team_score.toString(),
+        text = game.homeTeamScore.toString(),
         fontFamily = FontFamily.Serif,
         fontSize = 24.sp,
         fontWeight = FontWeight.Bold,
@@ -206,7 +218,7 @@ fun DisplayOngoingOrPreviousInfo(game: Game) {
     )
     Box {
         Row(verticalAlignment = Alignment.CenterVertically) {
-            if (game.status == "Final" && game.home_team_score > game.visitor_team_score) {
+            if (game.status == "Final" && game.homeTeamScore > game.visitorTeamScore) {
                 Icon(
                     Icons.AutoMirrored.Filled.ArrowBack,
                     contentDescription = "Left team won",
@@ -222,7 +234,7 @@ fun DisplayOngoingOrPreviousInfo(game: Game) {
                 fontWeight = FontWeight.Bold,
                 modifier = Modifier.padding(vertical = 4.dp)
             )
-            if (game.status == "Final" && game.visitor_team_score > game.home_team_score) {
+            if (game.status == "Final" && game.visitorTeamScore > game.homeTeamScore) {
                 Icon(
                     Icons.AutoMirrored.Filled.ArrowForward,
                     contentDescription = "Right team won",
@@ -233,7 +245,7 @@ fun DisplayOngoingOrPreviousInfo(game: Game) {
         }
     }
     Text(
-        text = game.visitor_team_score.toString(),
+        text = game.visitorTeamScore.toString(),
         fontFamily = FontFamily.Serif,
         fontSize = 24.sp,
         fontWeight = FontWeight.Bold,

--- a/app/src/main/java/com/example/jetpacktest/screens/HomeScreen.kt
+++ b/app/src/main/java/com/example/jetpacktest/screens/HomeScreen.kt
@@ -31,7 +31,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.example.jetpacktest.R
 import com.example.jetpacktest.models.StatLeader
 import com.example.jetpacktest.ui.components.ExpandableCard
 import com.example.jetpacktest.ui.theme.JetpackTestTheme
@@ -46,7 +45,7 @@ fun HomeScreen(
     val yearOptions = listOf("2009", "2010", "2011", "2012", "2013", "2014",
             "2015", "2016", "2017", "2018", "2019", "2020", "2021", "2022",
             "2023", "2024").reversed()
-    val statOptions = listOf("PTS", "AST", "TRB", "BLK", "STL")
+    val statOptions = listOf("Points", "Assists", "Rebounds", "Blocks", "Steals")
     //TODO:Change it so we pass just the states and lambdas, not entire Viewmodel
     val statLeadersList by homeViewModel.statLeadersListFlow.collectAsState(initial = emptyList())
     val chosenStat by homeViewModel.chosenStatFlow.collectAsState(initial = "PTS")
@@ -122,7 +121,6 @@ fun RandomStatCard(randomStat: String) {
     ExpandableCard(
         title = "Random Stat of the Day",
         description = randomStat,
-        backgroundColorResource = R.color.purple_lakers
     )
 }
 
@@ -132,7 +130,7 @@ fun StatLeaderCard(statLeader: StatLeader, chosenStat: String,
     Card(
         modifier = Modifier.padding(8.dp),
         elevation = CardDefaults.cardElevation(
-            defaultElevation = 10.dp //Adds a 'shadow' effect
+            defaultElevation = 10.dp
         ),
         colors = CardDefaults.cardColors(
             containerColor = Color.White,

--- a/app/src/main/java/com/example/jetpacktest/screens/ProfileScreen.kt
+++ b/app/src/main/java/com/example/jetpacktest/screens/ProfileScreen.kt
@@ -1,7 +1,8 @@
 package com.example.jetpacktest.screens
 
-import ReturnToPreviousHeader
 import android.util.Log
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -18,11 +19,12 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.ArrowDropUp
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.StarBorder
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
@@ -36,44 +38,55 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.jetpacktest.ApiHandler
 import com.example.jetpacktest.DatabaseHandler
+import com.example.jetpacktest.FavoritesHandler
 import com.example.jetpacktest.R
 import com.example.jetpacktest.HeadshotHandler
-import com.example.jetpacktest.models.NbaTeam
+import com.example.jetpacktest.models.TeamMaps
 import com.example.jetpacktest.ui.components.LargeDropdownMenu
 import com.example.jetpacktest.models.Player
+import com.example.jetpacktest.models.PlayerPersonalInfo
 import com.example.jetpacktest.ui.components.CircularLoadingIcon
+import com.example.jetpacktest.ui.components.ReturnToPreviousHeader
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
-fun ProfileScreen(playerName: String, navigateBack: () -> Unit) {
+fun ProfileScreen(
+    playerName: String,
+    navigateBack: () -> Unit,
+    getPreviousScreenName: () -> (String?),
+    showSnackBar: (String) -> Unit
+) {
     val headshotHandler = HeadshotHandler()
     val databaseHandler = DatabaseHandler()
-    //val context = LocalContext.current
     val apiHandler = ApiHandler()
-    //var imgUrl by remember { mutableStateOf("") }
+    val context = LocalContext.current
+    val favoritesHandler = FavoritesHandler(context)
     var imgId by rememberSaveable { mutableIntStateOf(-1) }
     var yearsList by rememberSaveable { mutableStateOf<List<String>>(emptyList()) }
     var chosenYear by rememberSaveable { mutableStateOf("") }
     var player by rememberSaveable { mutableStateOf(Player()) }
-    var showExpandedData by rememberSaveable { mutableStateOf(false) }
-    var isFetching by rememberSaveable { mutableStateOf(true) }
+    var isFetchingStats by rememberSaveable { mutableStateOf(true) }
+    var isFetchingInfo by rememberSaveable { mutableStateOf(true) }
+    var injuryStartDate by rememberSaveable { mutableStateOf("")}
+    var playerPersonalInfo by rememberSaveable { mutableStateOf(PlayerPersonalInfo(emptyList())) }
 
-    //TODO: add favorite functionality and maybe switch to viewmodel?
     LaunchedEffect(Unit) {
-
+        //We use conditionals to make sure these aren't re-fetched on screen swaps
         if (imgId == -1) {
             Log.d("ProfileScreen", "Updating headshot")
             headshotHandler.fetchImageId(playerName) { result ->
                 imgId = result
             }
         }
-
         if (yearsList.isEmpty()) {
             Log.d("ProfileScreen", "Fetching new years")
             databaseHandler.executeYears(playerName = playerName) {result ->
@@ -85,34 +98,79 @@ fun ProfileScreen(playerName: String, navigateBack: () -> Unit) {
                     //Then, fetch all our data for that most recent year
                     databaseHandler.executePlayerData(playerName, chosenYear) { data ->
                         player = data
-                        isFetching = false
+                        isFetchingStats = false
                     }
                 }
             }
         }
+        if (injuryStartDate == "") {
+            Log.d("ProfileScreen", "Checking if injured or not")
+            databaseHandler.executeCheckInjuredStartDate(playerName = playerName) { result ->
+                injuryStartDate = result
+            }
+        }
+        if (playerPersonalInfo.data.isEmpty()) {
+            Log.d("ProfileScreen", "Fetching personal info")
+            playerPersonalInfo = apiHandler.fetchPlayerInfo(playerName = playerName)
+            isFetchingInfo = false
+        }
     }
 
-    Box(modifier = Modifier.fillMaxSize()) {
-        //Have to wrap inside column for Spacer to work
-        Column(modifier = Modifier.fillMaxSize()) {
-            //Calls composable that sets up our back header to go back to search
-            ReturnToPreviousHeader(navigateBack = navigateBack)
-            //Adds space between header and actual data
+
+    LazyColumn(modifier = Modifier.fillMaxSize()) {
+        stickyHeader {
+            ReturnToPreviousHeader(
+                navigateBack = navigateBack,
+                label = getPreviousScreenName()?.let { screenName ->
+                    if (screenName.contains("team")) "Team Profile"
+                    else screenName.dropLast(6)
+                } ?: ""
+            )
+        }
+        item {
             Spacer(modifier = Modifier.height(15.dp))
-            if (isFetching) {
-                CircularLoadingIcon()
-            }
-            else {
+        }
+
+        if (isFetchingStats || isFetchingInfo) {
+            item { CircularLoadingIcon() }
+        } else {
+            item {
                 NameAndHeadshot(
                     playerName = playerName,
                     imgId = imgId,
-                    team =  player.team,
+                    team = player.team,
                     position = player.position,
-                    headshotHandler = headshotHandler
+                    jerseyNumber = playerPersonalInfo.data[0].jerseyNumber,
+                    injuryStartDate = injuryStartDate,
+                    headshotHandler = headshotHandler,
+                    favoritesHandler = favoritesHandler,
+                    showSnackBar = showSnackBar
                 )
+            }
+
+            item {
                 HorizontalDivider(thickness = 2.dp, color = Color.White)
+            }
+
+            item {
                 MainStatBoxes(player = player)
-                //Custom Dropdown menu for each year
+            }
+
+            item {
+                HorizontalDivider(thickness = 2.dp, color = Color.White)
+            }
+
+            item {
+                InfoStatBoxes(
+                    playerPersonalInfo = playerPersonalInfo,
+                    color = colorResource(
+                        TeamMaps.teamColorsMap[player.team.split("/")[0]]
+                            ?: R.color.purple_lakers
+                    )
+                )
+            }
+
+            item {
                 LargeDropdownMenu(
                     label = "Select Year:",
                     items = yearsList,
@@ -120,31 +178,36 @@ fun ProfileScreen(playerName: String, navigateBack: () -> Unit) {
                     onItemSelected = { index, _ ->
                         chosenYear = yearsList[index]
                         if (chosenYear != "2024") {
-                            databaseHandler.executePlayerData(playerName, chosenYear) { data ->
+                            databaseHandler.executePlayerData(
+                                playerName,
+                                chosenYear
+                            ) { data ->
                                 player = data
                             }
-                        }
-                        else {
-                            databaseHandler.executePlayerData(playerName, chosenYear) { data ->
+                        } else {
+                            //TODO: Call upon API later for 2024 data
+                            databaseHandler.executePlayerData(
+                                playerName,
+                                chosenYear
+                            ) { data ->
                                 player = data
                             }
-                            /*
-                            apiHandler.fetchPlayerData(
-                                context,
-                                onResult = {data ->
-                                    player = data
-                                }
-                            )
-                             */
                         }
                     }
                 )
-                //Now, compose our button that toggles the extra data in list
-                ToggleFurtherStats(showExpandedData = showExpandedData,
-                    onClick = { showExpandedData = !showExpandedData })
-                //Show the extra data only if user toggled via button above (and player has stats)
-                if (showExpandedData && player.points != -1.0f) {
-                    PlayerDataTable(player)
+            }
+            /*
+            item {
+                ToggleFurtherStats(
+                    showExpandedData = showExpandedData,
+                    onClick = { showExpandedData = !showExpandedData }
+                )
+            }
+             */
+
+            if (player.points != -1.0f) { // && showExpandedData
+                item {
+                    PlayerStatisticTable(player)
                 }
             }
         }
@@ -157,17 +220,22 @@ fun NameAndHeadshot(
     imgId: Int,
     team: String,
     position: String,
-    headshotHandler: HeadshotHandler
+    jerseyNumber: String,
+    injuryStartDate: String,
+    headshotHandler: HeadshotHandler,
+    favoritesHandler: FavoritesHandler,
+    showSnackBar: (String) -> Unit
 ) {
-    var isFavorite by remember { mutableStateOf(false) }
-    //We use a box to color the background
+    var isFavorite by remember {
+        mutableStateOf(favoritesHandler.getFavoritePlayers().contains(playerName))
+    }
     Box(
         modifier = Modifier
             .fillMaxWidth()
             .background(
                 color = colorResource(
                     //Split by / in case two teams
-                    NbaTeam.teamColorsMap[team.split("/")[0]] ?: R.color.purple_lakers
+                    TeamMaps.teamColorsMap[team.split("/")[0]] ?: R.color.purple_lakers
                 )
             )
             .offset(y = 20.dp) //Move image down a bit
@@ -190,20 +258,35 @@ fun NameAndHeadshot(
             Column {
                 Row(modifier = Modifier.padding(end = 8.dp)) {
                     Text(
-                        text = "$team | $position",
-                        fontSize = 14.sp,
+                        text = "$team | $position | #$jerseyNumber",
+                        fontSize = 16.sp,
                         color = Color.White
                     )
                     Spacer(modifier = Modifier.weight(1f))
                     Icon(
-                        imageVector =  if (isFavorite) Icons.Filled.Star
-                        else Icons.Outlined.StarBorder,
+                        imageVector = if (isFavorite) Icons.Filled.Star
+                                      else Icons.Outlined.StarBorder,
                         contentDescription = "Favorite",
                         tint = if (isFavorite) Color.Yellow else Color.White,
                         modifier = Modifier
                             .size(24.dp)
-                            .clickable(onClick = { isFavorite = !isFavorite })
+                            .clickable(
+                                onClick = {
+                                    isFavorite = !isFavorite
+                                    if (isFavorite) {
+                                        val favoriteAdded =
+                                            favoritesHandler.addFavoritePlayer(playerName)
+                                        if (!favoriteAdded) {
+                                            showSnackBar("Sorry, too many favorites!")
+                                            isFavorite = !isFavorite
+                                        }
+                                    } else {
+                                        favoritesHandler.removeFavoritePlayer(playerName)
+                                    }
+                                }
+                            )
                     )
+
                 }
                 Text(
                     text = playerName,
@@ -212,8 +295,34 @@ fun NameAndHeadshot(
                     color = Color.White,
                     textAlign = TextAlign.Start
                 )
+                Spacer(modifier = Modifier.height(10.dp))
+                //Display injury notifier if so
+                if (injuryStartDate != "N/A") {
+                    Text(
+                        text = "Injured since ${injuryStartDate.dropLast(9)}",
+                        fontSize = 14.sp,
+                        color = Color.White
+                    )
+                }
             }
         }
+    }
+}
+
+@Composable
+fun StatBox(
+    label: String,
+    value: String,
+    labelFontSize: TextUnit = 16.sp,
+    valueFontSize: TextUnit = 16.sp
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(label, fontSize = labelFontSize,
+            color = Color.White)
+        Text(value, fontSize = valueFontSize, fontWeight = FontWeight.Bold,
+            color = Color.White)
     }
 }
 
@@ -227,7 +336,7 @@ fun MainStatBoxes(player: Player) {
             .fillMaxWidth()
             .background(
                 color = colorResource(
-                    NbaTeam.teamColorsMap[player.team.split("/")[0]]
+                    TeamMaps.teamColorsMap[player.team.split("/")[0]]
                         ?: R.color.purple_lakers
                 )
             ),
@@ -254,95 +363,152 @@ fun MainStatBoxes(player: Player) {
 }
 
 @Composable
-fun StatBox(label: String, value: String) {
+fun InfoStatBoxes(playerPersonalInfo: PlayerPersonalInfo, color: Color) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(color = color),
+        horizontalArrangement = Arrangement.SpaceEvenly,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        StatBox(
+            label = "Height/Weight",
+            value = "${playerPersonalInfo.data[0].height} | " +
+                    playerPersonalInfo.data[0].weight,
+            labelFontSize = 14.sp,
+            valueFontSize = 16.sp
+        )
+        VerticalDivider(modifier = Modifier.height(50.dp),
+            thickness = 2.dp, color = Color.White)
+        StatBox(
+            label = "Draft",
+            value = if (playerPersonalInfo.data[0].draftYear != 0)
+                "${playerPersonalInfo.data[0].draftYear} " +
+                        "Round ${playerPersonalInfo.data[0].draftRound} " +
+                        "Pick ${playerPersonalInfo.data[0].draftNumber}"
+            else "Undrafted",
+            labelFontSize = 14.sp,
+            valueFontSize = 16.sp
+        )
+    }
+    HorizontalDivider(thickness = 2.dp, color = Color.White)
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(color = color),
+        horizontalArrangement = Arrangement.SpaceEvenly,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        StatBox(
+            label = "College",
+            value = playerPersonalInfo.data[0].college,
+            labelFontSize = 14.sp,
+            valueFontSize = 16.sp
+        )
+        VerticalDivider(modifier = Modifier.height(50.dp),
+            thickness = 2.dp, color = Color.White)
+        StatBox(
+            label = "Country",
+            value = playerPersonalInfo.data[0].country,
+            labelFontSize = 14.sp,
+            valueFontSize = 16.sp
+        )
+    }
+}
+
+@Composable
+fun PlayerStatisticTable(player: Player) {
     Column(
-        horizontalAlignment = Alignment.CenterHorizontally
+        modifier = Modifier
+            .padding(16.dp)
     ) {
-        Text(label, fontSize = 16.sp, fontWeight = FontWeight.Bold,
-            color = Color.White)
-        Text(value, fontSize = 16.sp, fontWeight = FontWeight.Bold,
-            color = Color.White)
-    }
-}
-
-@Composable
-fun ToggleFurtherStats(onClick: () -> Unit, showExpandedData: Boolean) {
-    //Toggles the extra stats
-    Box(
-        modifier = Modifier.fillMaxWidth(),
-        contentAlignment = Alignment.Center
-    ) {
-        OutlinedButton(
-            onClick = onClick
-        ) {
-            Text(if (showExpandedData) "Shrink Further Stats" else "Expand Further Stats")
+        Spacer(modifier = Modifier.height(4.dp))
+        StatisticCategory("Shooting Splits") {
+            Column(
+                modifier = Modifier
+                    .padding(4.dp)
+            ) {
+                PlayerDataRow("Field Goals", player.fieldGoals.toString())
+                PlayerDataRow("Field Goal Attempts", player.fieldGoalAttempts.toString())
+                PlayerDataRow("Field Goal %", "%.1f%%"
+                    .format(player.fieldGoalPercent * 100))
+                PlayerDataRow("3 Pointers", player.threePointers.toString())
+                PlayerDataRow("3 Point Attempts", player.threePointerAttempts.toString())
+                PlayerDataRow("3 Point %", "%.1f%%"
+                    .format(player.threePointPercent * 100))
+                PlayerDataRow("2 Pointers", player.twoPointers.toString())
+                PlayerDataRow("2 Point Attempts", player.twoPointerAttempts.toString())
+                PlayerDataRow("2 Point %", "%.1f%%"
+                    .format(player.twoPointPercent * 100))
+                PlayerDataRow(
+                    "Effective FG%",
+                    "%.1f%%".format(player.effectiveFieldGoalPercent * 100)
+                )
+            }
+        }
+        StatisticCategory("Defensive Efficiency and Usage") {
+            Column(
+                modifier = Modifier
+                    .padding(4.dp)
+            ) {
+                PlayerDataRow("Steals", player.steals.toString())
+                PlayerDataRow("Blocks", player.blocks.toString())
+                PlayerDataRow("Fouls", player.personalFouls.toString())
+                PlayerDataRow("Turnovers", player.turnovers.toString())
+                PlayerDataRow("Mins. Played", player.minutesPlayed.toString())
+            }
         }
     }
 }
 
 @Composable
-fun PlayerDataTable(player: Player) {
-    //Slight amount of vertical space
-    Spacer(modifier = Modifier.height(4.dp))
-    //Now the actual list of values
-    LazyColumn(
-        modifier = Modifier.padding(16.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        //Pass in list of rows with Label and Value
-        item {
-            //PlayerDataRow("Year", player.year.toString())
-            //PlayerDataRow("Position", player.position)
-            //PlayerDataRow("Team", player.team)
-            //PlayerDataRow("Points", player.points.toString())
-            //PlayerDataRow("Assists", player.assists.toString())
-            //PlayerDataRow("Rebounds", player.totalRebounds.toString())
-            PlayerDataRow("Steals", player.steals.toString())
-            PlayerDataRow("Blocks", player.blocks.toString())
-            PlayerDataRow("FG", player.fieldGoals.toString())
-            PlayerDataRow("FGA", player.fieldGoalAttempts.toString())
-            PlayerDataRow("FG%", "%.1f%%".format(player.fieldGoalPercent * 100))
-            PlayerDataRow("3P ", player.threePointers.toString())
-            PlayerDataRow("3PA", player.threePointerAttempts.toString())
-            PlayerDataRow("3P%", "%.1f%%".format(player.threePointPercent * 100))
-            PlayerDataRow("Turnovers", player.turnovers.toString())
-            PlayerDataRow("Fouls", player.personalFouls.toString())
-            PlayerDataRow("Mins. Played", player.minutesPlayed.toString())
-            PlayerDataRow("2P", player.twoPointers.toString())
-            PlayerDataRow("2PA", player.twoPointerAttempts.toString())
-            PlayerDataRow("2P%", "%.1f%%".format(player.twoPointPercent * 100))
-            PlayerDataRow("EFG%", "%.1f%%".format(player.effectiveFieldGoalPercent * 100))
-            //PlayerDataRow("ORB", player.offensiveRebounds.toString())
-            //PlayerDataRow("DRB", player.defensiveRebounds.toString())
-        }
+fun StatisticCategory(title: String, content: @Composable () -> Unit) {
+    var expandedCategory by remember { mutableStateOf(false) }
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable {expandedCategory = !expandedCategory }
+    ){
+        Text(
+            text = title,
+            modifier = Modifier.padding(8.dp),
+            fontSize = 18.sp,
+            fontWeight = FontWeight.Bold
+        )
+        Icon(
+            imageVector = if (expandedCategory) Icons.Filled.ArrowDropUp
+                        else Icons.Filled.ArrowDropDown,
+            contentDescription = null,
+            modifier = Modifier.size(24.dp)
+        )
+    }
+    AnimatedVisibility(visible = expandedCategory) {
+        content() // Lambda of rows that we passed in for that specific category
     }
 }
 
 @Composable
 fun PlayerDataRow(label: String, value: String) {
-    Column {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.Center
-        ) {
-            //Prints label aligned to the left
-            Text(
-                label,
-                fontSize = 22.sp,
-                fontWeight = FontWeight.Bold,
-                modifier = Modifier.weight(1f)
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-            //Prints actual value aligned to the right
-            Text(
-                value,
-                fontSize = 22.sp,
-                textAlign = TextAlign.End,
-                modifier = Modifier.weight(1f)
-            )
-        }
-        HorizontalDivider()
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Center
+    ) {
+        Text(
+            label,
+            fontSize = 16.sp,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.weight(1f)
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            value,
+            fontSize = 16.sp,
+            textAlign = TextAlign.End,
+            modifier = Modifier.weight(1f)
+        )
     }
-
+    HorizontalDivider()
 }

--- a/app/src/main/java/com/example/jetpacktest/screens/StandingsScreen.kt
+++ b/app/src/main/java/com/example/jetpacktest/screens/StandingsScreen.kt
@@ -1,22 +1,204 @@
 package com.example.jetpacktest.screens
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.VerticalDivider
+import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.example.jetpacktest.dropZeroBeforeDecimal
+import com.example.jetpacktest.models.TeamStanding
+import kotlinx.coroutines.flow.Flow
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
-fun StandingsScreen() {
-    Box(modifier = Modifier
-        .fillMaxSize(),
-        contentAlignment = Alignment.Center)
-    {
-        Text(text = "Standings Screen",
-            fontFamily = FontFamily.Serif,
-            fontSize = 22.sp)
+fun StandingsScreen(
+    westernFlow: Flow<List<TeamStanding>>,
+    easternFlow: Flow<List<TeamStanding>>,
+    navigateToTeamProfile: (String) -> Unit,
+    navigateToBrackets: () -> Unit
+) {
+    val westernStandings by westernFlow.collectAsState(initial = emptyList())
+    val easternStandings by easternFlow.collectAsState(initial = emptyList())
+
+    val combinedStandings = easternStandings + westernStandings
+
+    LazyColumn {
+        stickyHeader {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(MaterialTheme.colorScheme.surfaceColorAtElevation(3.dp))
+                    .padding(8.dp)
+            ) {
+                Text(
+                    text = "Standings",
+                    fontSize = 24.sp,
+                    fontWeight = FontWeight.Bold,
+                    textAlign = TextAlign.Start,
+                    fontFamily = FontFamily.Serif,
+                )
+                Row(
+                    horizontalArrangement = Arrangement.End,
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.clickable {
+                        navigateToBrackets()
+                    }
+                ) {
+                    Text(
+                        text = "Bracket",
+                        fontSize = 24.sp,
+                        fontWeight = FontWeight.Bold,
+                        textAlign = TextAlign.End,
+                        fontFamily = FontFamily.Serif,
+                    )
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowForward,
+                        contentDescription = null
+                    )
+                }
+            }
+        }
+        //Group by Conference to organize West/East
+        combinedStandings.groupBy { it.conference}.forEach { mapEntry ->
+            stickyHeader { ConferenceHeader(
+                conferenceName = mapEntry.key.name.take(4)
+            ) }
+            items(mapEntry.value) { standing ->
+                TeamStandingRow(
+                    teamStanding = standing,
+                    navigateToTeamProfile = navigateToTeamProfile
+                )
+                HorizontalDivider(color = MaterialTheme.colorScheme.surfaceColorAtElevation(3.dp))
+            }
+        }
     }
 }
+
+@Composable
+fun ConferenceHeader(conferenceName: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(
+                MaterialTheme.colorScheme.surfaceColorAtElevation(3.dp) // Same as Nav-Bar
+            )
+    ) {
+        Text(
+            text = conferenceName,
+            fontSize = 15.sp,
+            fontWeight = FontWeight.Bold,
+            fontFamily = FontFamily.Serif,
+            modifier = Modifier
+                .padding(8.dp)
+        )
+        Spacer(modifier = Modifier.width(99.dp))
+        Text(
+            text = "W",
+            fontSize = 15.sp,
+            fontWeight = FontWeight.Bold,
+            fontFamily = FontFamily.Serif,
+            modifier = Modifier
+                .padding(8.dp)
+        )
+        Spacer(modifier = Modifier.width(45.dp))
+        Text(
+            text = "L",
+            fontSize = 15.sp,
+            fontWeight = FontWeight.Bold,
+            fontFamily = FontFamily.Serif,
+            modifier = Modifier
+                .padding(8.dp)
+        )
+        Spacer(modifier = Modifier.width(46.dp))
+        Text(
+            text = "PCT",
+            fontSize = 15.sp,
+            fontWeight = FontWeight.Bold,
+            fontFamily = FontFamily.Serif,
+            modifier = Modifier
+                .padding(8.dp)
+        )
+    }
+}
+
+@Composable
+fun TeamStandingRow(teamStanding: TeamStanding, navigateToTeamProfile: (String) -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(Color.White)
+            .padding(8.dp),
+    ) {
+        Text(
+            text = "${teamStanding.rank}",
+            modifier = Modifier
+                .weight(0.5f)
+                .padding(horizontal = 5.dp)
+        )
+        Image(
+            painter = painterResource(id = teamStanding.logo),
+            contentDescription = "Logo",
+            modifier = Modifier
+                .size(35.dp)
+                .sizeIn(maxWidth = 35.dp, maxHeight = 35.dp)
+                .weight(0.5f)
+                .clickable { navigateToTeamProfile(teamStanding.name) }
+        )
+        Text(
+            text = teamStanding.abbrev,
+            modifier = Modifier
+                .weight(1f)
+                .padding(start = 5.dp)
+        )
+        VerticalDivider(
+            color = MaterialTheme.colorScheme.surfaceColorAtElevation(3.dp),
+            thickness = 1.dp,
+            modifier = Modifier
+                .height(43.dp)
+                .fillMaxHeight()
+                .offset(x = (-20).dp)
+                .padding(end = 5.dp)
+        )
+        Text(text = "${teamStanding.wins}", modifier = Modifier.weight(1f))
+        Text(text = "${teamStanding.losses}", modifier = Modifier.weight(1f))
+        Text(
+            text = dropZeroBeforeDecimal(teamStanding.winLossPercentage),
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+

--- a/app/src/main/java/com/example/jetpacktest/ui/components/ExpandableCard.kt
+++ b/app/src/main/java/com/example/jetpacktest/ui/components/ExpandableCard.kt
@@ -16,7 +16,9 @@ import androidx.compose.material.icons.filled.ArrowDropUp
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -25,12 +27,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
@@ -38,7 +38,6 @@ import androidx.compose.ui.unit.sp
 fun ExpandableCard(
     title: String,
     description: String,
-    backgroundColorResource: Int
 ) {
     //Savable used to persist state across diff screen swaps
     var isExpanded by rememberSaveable { mutableStateOf(false) }
@@ -57,8 +56,8 @@ fun ExpandableCard(
             defaultElevation = 10.dp //Adds a 'shadow' effect
         ),
         colors = CardDefaults.cardColors(
-            containerColor = colorResource(backgroundColorResource),
-            contentColor = Color.White
+            containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(3.dp),
+            contentColor = Color.Black
         )
     ) {
         Column(
@@ -74,7 +73,6 @@ fun ExpandableCard(
                 Text(
                     text = title,
                     style = TextStyle(
-                        textDecoration = TextDecoration.Underline,
                         fontWeight = FontWeight.Bold,
                         fontSize = 20.sp,
                         textAlign = TextAlign.Center
@@ -85,7 +83,7 @@ fun ExpandableCard(
                     imageVector = if (isExpanded) Icons.Filled.ArrowDropUp
                                     else Icons.Filled.ArrowDropDown,
                     contentDescription = "Arrow",
-                    tint = Color.White,
+                    tint = Color.Black,
                     modifier = Modifier.weight(1f)
                 )
             }

--- a/app/src/main/java/com/example/jetpacktest/ui/components/ReturnToPreviousHeader.kt
+++ b/app/src/main/java/com/example/jetpacktest/ui/components/ReturnToPreviousHeader.kt
@@ -1,15 +1,20 @@
+package com.example.jetpacktest.ui.components
+
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontFamily
@@ -18,16 +23,24 @@ import androidx.compose.ui.unit.sp
 import com.example.jetpacktest.R
 
 @Composable
-fun ReturnToPreviousHeader(navigateBack: () -> Unit, label: String = "Previous") {
+fun ReturnToPreviousHeader(
+    navigateBack: () -> Unit,
+    label: String? = "Previous"
+) {
     Column(
-        modifier = Modifier.padding(10.dp),
+        modifier = Modifier
+            .fillMaxWidth(),
         verticalArrangement = Arrangement.Top
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.clickable {
-                navigateBack()
-            }
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(50.dp)
+                .background(Color.White)
+                .clickable {
+                    navigateBack()
+                }
         ) {
             Icon(
                 imageVector = ImageVector.vectorResource(R.drawable.baseline_arrow_back_ios_new_24),

--- a/app/src/main/java/com/example/jetpacktest/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/com/example/jetpacktest/viewmodels/HomeViewModel.kt
@@ -8,10 +8,19 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 
 class HomeViewModel : ViewModel() {
+    companion object {
+        val statMap = mapOf(
+            "Points" to "PTS",
+            "Assists" to "AST",
+            "Rebounds" to "TRB",
+            "Steals" to "STL",
+            "Blocks" to "BLK"
+        )
+    }
     private val databaseHandler = DatabaseHandler()
 
     // Flows for the selected stat and year
-    private val _chosenStatFlow = MutableStateFlow("PTS")
+    private val _chosenStatFlow = MutableStateFlow("Points")
     val chosenStatFlow: Flow<String> = _chosenStatFlow
 
     private val _chosenYearFlow = MutableStateFlow("2024")
@@ -21,7 +30,7 @@ class HomeViewModel : ViewModel() {
     val statLeadersListFlow: Flow<List<StatLeader>> = _statLeadersListFlow
 
     fun fetchStatLeaders() {
-        val chosenStat = _chosenStatFlow.value
+        val chosenStat = statMap[_chosenStatFlow.value] ?: "PTS"
         val chosenYear = _chosenYearFlow.value
         Log.d("HomeVM", "Fetching new stat leads")
         databaseHandler.executeStatLeaders(chosenStat = chosenStat, year = chosenYear) { statLeaders ->

--- a/app/src/main/java/com/example/jetpacktest/viewmodels/SearchViewModel.kt
+++ b/app/src/main/java/com/example/jetpacktest/viewmodels/SearchViewModel.kt
@@ -1,14 +1,12 @@
 package com.example.jetpacktest.viewmodels
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.jetpacktest.DatabaseHandler
 import com.example.jetpacktest.RestHandler
-import com.example.jetpacktest.models.NbaTeam
+import com.example.jetpacktest.models.TeamMaps
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
-import java.net.SocketTimeoutException
 
 
 @OptIn(FlowPreview::class)
@@ -92,10 +90,10 @@ class SearchViewModel() : ViewModel() {
     val teamResults = searchText
         .flatMapLatest { text ->
             if (text.isBlank()) {
-                flowOf(NbaTeam.names)
+                flowOf(TeamMaps.names)
             } else {
                 flow {
-                    val filteredTeams = NbaTeam.names.filter { teamName ->
+                    val filteredTeams = TeamMaps.names.filter { teamName ->
                         teamName.contains(text, ignoreCase = true)
                     }
                     emit(filteredTeams)

--- a/app/src/main/java/com/example/jetpacktest/viewmodels/StandingsViewModel.kt
+++ b/app/src/main/java/com/example/jetpacktest/viewmodels/StandingsViewModel.kt
@@ -1,0 +1,43 @@
+package com.example.jetpacktest.viewmodels
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import com.example.jetpacktest.DatabaseHandler
+import com.example.jetpacktest.models.TeamStanding
+import com.example.jetpacktest.models.TeamStanding.Conference
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+class StandingsViewModel : ViewModel() {
+    private val databaseHandler = DatabaseHandler()
+
+    private val _westernFlow = MutableStateFlow<List<TeamStanding>>(emptyList())
+    val westernFlow: Flow<List<TeamStanding>> = _westernFlow
+
+    private val _easternFlow = MutableStateFlow<List<TeamStanding>>(emptyList())
+    val easternFlow: Flow<List<TeamStanding>> = _easternFlow
+
+    init {
+        fetchWesternStandings()
+        fetchEasternStandings()
+    }
+
+    private fun fetchWesternStandings() {
+        Log.d("StandingsVM", "Fetching Western Standings...")
+        databaseHandler.executeStandings(
+            conference = Conference.WESTERN,
+        ) { teamStandings ->
+            _westernFlow.value = teamStandings
+        }
+    }
+
+    private fun fetchEasternStandings() {
+        Log.d("StandingsVM", "Fetching Eastern Standings...")
+        databaseHandler.executeStandings(
+            conference = Conference.EASTERN
+        ) { teamStandings ->
+            _easternFlow.value = teamStandings
+        }
+    }
+
+}

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -36,8 +36,10 @@
     <color name="phx">#1D1160</color>
     <color name="por">#E03A3E</color>
     <color name="sac">#5A2D81</color>
-    <color name="sas">#C4CED4</color>
+    <color name="sas">#000000</color>
     <color name="tor">#CE1141</color>
     <color name="uta">#002B5C</color>
     <color name="was">#E31837</color>
+
+    <color name="higherStat">#E4F4E4</color>
 </resources>


### PR DESCRIPTION
* Injury feature (#11)

* Added worker class

* Implemented functions that store and fetch injured players into database, and work manager that stores every 7 days. Also added the text that shows when that player was injured (if they are injured)

* Updated ProfileScreen so it includes personal info Also added in specific labels for previous, and commented out fetching headshot from API

* removed extra imports

* Print 'Undrafted' on Profile Screen if undrafted like yuta

* Moved 'removeAccents' to a new utilities file, and called it in ApiHandler to make it work for luka

* Deleted commented code in api/headshot handler and removed imports

* Added favorites, but toast is completely broken

* split up team profile into own func for header

* Removed commented out code in Main

* Removed commented out code in Main

* Removed commented out code in Main

* Made entire profile scrollable

* Changed spurs color from white to black for readability Also made return a sticky header in ProfileScreen and added detection of no on-going games in GamesScreen

* removed extra import/todo

* Changed HomeScreen stat labels to full words instead of abbreviation for clarity, and fixed bug with databaseHandler when querying apostrophe in name

* Commented out old Executor Code in DatabaseHandler

* Changed NbaTeam object name to TeamMaps

* Deleted commented out OldGame class in Game.kt

* Serialized the names of several data classes, so it's not using API syntax which wasn't camel case

* Deleted commented out function in SearchScreen

* Added (Unused) TeamStanding data class that we'll use to store database standings

* Swapped from Toast -> Snackbar for ProfileScreen Favorites error

* Removed old toast imports

---------

Co-authored-by: niko <>

* Bracket feature (#13)

* changed paranthese placement in standings

* Changed the name of the stats to make them more user friendly Added template for fetching standings

* Changed Compare a bit, just messing around with layout

* Fixed CompareResults logic bug and changed color of expandablecard and games screen date picker

* removed extra imports

* removed underline from title of random stat of the day

* Updated UI of ProfileScreen to be more organized

* removed old import/variable

* Added 'launchSingleTop' to navigation lambdas to prevent fast clicking on buttons leading to double navigations

* Added utility function and revised TeamMaps object

* Playing around with standings

* Added Jared's Bracket Screen from other branch and made it accessible from Standings

* Fixed issue with the Package location of ReturnToPreviousHeader

* Added team to compare so we know the team that year, as well as fixed spacing in brackets page

* Added team to compare so we know the team that year, as well as fixed spacing in brackets page

* updated playoff scores

---------


Co-authored-by: niko <>


---------